### PR TITLE
feat: 홈 화면 및 루트 레이아웃 리팩토링 및 인증 UI 통합

### DIFF
--- a/src/app/layout.module.scss
+++ b/src/app/layout.module.scss
@@ -1,0 +1,17 @@
+@use '../styles' as *;
+
+.wrapper {
+  @include flex-center;
+  min-height: 100vh;
+  background: $off-white;
+}
+
+.container {
+  width: 100%;
+  max-width: 1400px;
+  min-height: 100vh;
+  background: $white;
+  box-shadow: $shadow-md;
+  position: relative;
+  overflow-y: auto;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from 'next';
-import './globals.css';
+
+import styles from './layout.module.scss';
+
+import AuthForm from '@/components/AuthForm/AuthForm';
+
+import '@/styles/globals.scss';
+import { Font } from '@/styles/fonts';
 
 export const metadata: Metadata = {
   title: '울끈불끈',
-  description: '울끈불끈',
+  description: '울끈불끈 당신의 성장을 기록하세요.',
 };
 
 export default function RootLayout({
@@ -13,7 +19,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ko'>
-      <body>{children}</body>
+      <body className={Font.variable}>
+        <div className={styles.wrapper}>
+          <main className={styles.container}>
+            <AuthForm />
+            {children}
+          </main>
+        </div>
+      </body>
     </html>
   );
 }

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -1,0 +1,45 @@
+@use '../styles' as *;
+
+.pageContainer {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.dashboardGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+  width: 100%;
+  margin-top: 20px;
+  margin-bottom: 20px;
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(2, 1fr);
+    align-items: stretch;
+
+    &.isGuest {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
+      & > div {
+        max-width: 600px;
+      }
+    }
+  }
+}
+
+.guestMessage {
+  width: 100%;
+  text-align: center;
+  padding: 3rem 2rem;
+  background: $off-white;
+  border: 1px solid $border-soft;
+  border-radius: 15px;
+
+  @media (min-width: 1024px) {
+    grid-column: span 2;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,40 @@
+'use client';
+
+import styles from './page.module.scss';
+
+import RecordForm from '@/components/RecordForm/RecordForm';
+import RecordList from '@/components/RecordList/RecordList';
+import RecordChart from '@/components/RecordChart/RecordChart';
+import ProfileCard from '@/components/Profile';
+import Empty from '@/components/shared/Empty/Empty';
+
+import { useAuth } from '@/hooks/useAuth';
+
 export default function Home() {
+  const { user, loading } = useAuth();
+
+  if (loading) return null;
+
   return (
-    <div>
-      <h1>Hello World!</h1>
+    <div className={styles.pageContainer}>
+      <div className={`${styles.dashboardGrid} ${!user ? styles.isGuest : ''}`}>
+        <RecordForm />
+
+        {user ? (
+          <>
+            <ProfileCard />
+            <RecordChart />
+            <RecordList />
+          </>
+        ) : (
+          <div className={styles.guestMessage}>
+            <Empty
+              message='로그인 후 기록을 시작해 볼까요?'
+              subMessage='나만의 운동 통계와 변화 그래프를 확인해 보세요.'
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -5,7 +5,7 @@
 }
 
 body {
-  background: #ffffff;
-  color: #000000;
   font-family: sans-serif;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
### 작업 내용
- 홈 화면에 로그인/비로그인 상태 분기 로직 구현
- 사용자 상태에 따라 대시보드 또는 게스트 화면 렌더링
- 루트 레이아웃 구조 리팩토링 및 `AuthForm` 통합
- 반응형 대시보드 그리드 및 게스트 뷰 `UI` 스타일링 추가
- 커스텀 폰트 클래스 적용 및 전체 폰트 일관화