### PR TITLE
feat: 멤버 페이지 추가 및 대시보드 연동

### DIFF
--- a/src/app/members/Members.module.scss
+++ b/src/app/members/Members.module.scss
@@ -1,0 +1,13 @@
+@use '../../styles' as *;
+
+.membersContainer {
+  max-width: 800px;
+  margin: 0 auto;
+
+  .title {
+    @include font-lg-title;
+    margin-bottom: 2rem;
+    color: $text-dark;
+    text-align: center;
+  }
+}

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import styles from './Members.module.scss';
+
+import NavBar from '@/components/shared/NavBar/NavBar';
+
+export default function MembersPage() {
+  return (
+    <div className={styles.membersContainer}>
+      <NavBar href='/' label='대시보드로 돌아가기' />
+
+      <h1 className={styles.title}>🔥 울끈불끈이들 🔥</h1>
+    </div>
+  );
+}

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -2,7 +2,6 @@
 
 .pageContainer {
   width: 100%;
-  max-width: 1200px;
   margin: 0 auto;
   padding: 0 20px;
 }
@@ -12,7 +11,6 @@
   grid-template-columns: 1fr;
   gap: 20px;
   width: 100%;
-  margin-top: 20px;
   margin-bottom: 20px;
 
   @media (min-width: 1024px) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,9 @@ import RecordForm from '@/components/RecordForm/RecordForm';
 import RecordList from '@/components/RecordList/RecordList';
 import RecordChart from '@/components/RecordChart/RecordChart';
 import ProfileCard from '@/components/Profile';
+
 import Empty from '@/components/shared/Empty/Empty';
+import NavBar from '@/components/shared/NavBar/NavBar';
 
 import { useAuth } from '@/hooks/useAuth';
 
@@ -17,6 +19,8 @@ export default function Home() {
 
   return (
     <div className={styles.pageContainer}>
+      <NavBar href='/members' label='🔥 울끈불끈이들 기록 보러가기 🔥' />
+
       <div className={`${styles.dashboardGrid} ${!user ? styles.isGuest : ''}`}>
         <RecordForm />
 


### PR DESCRIPTION
### 작업 내용
- 유저들의 기록을 확인할 수 있는 멤버 페이지 `UI` 구조 구현
- 홈 페이지(대시보드)에 `NavBar` 추가 및 멤버 페이지 이동 링크 연결