### PR TITLE
feat: 멤버 목록 페이지 기능 및 UI 구현

### DIFF
--- a/src/app/members/Members.module.scss
+++ b/src/app/members/Members.module.scss
@@ -10,4 +10,96 @@
     color: $text-dark;
     text-align: center;
   }
+
+  .userGrid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    margin: 20px;
+
+    @media (min-width: 600px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    .userCard {
+      @include flex-center;
+      padding: 1.25rem;
+      background-color: $white;
+      border-radius: $radius-main;
+      border: 1px solid $border-soft;
+      text-decoration: none;
+      color: inherit;
+      transition: $transition-base;
+      position: relative;
+
+      &:hover {
+        transform: $lift-sm;
+        border-color: $blue;
+        box-shadow: 0 4px 12px rgba(0, 123, 255, 0.2);
+      }
+    }
+
+    .avatarWrapper {
+      @include flex-center;
+      width: 50px;
+      height: 50px;
+      margin-right: 1.5rem;
+      border-radius: 50%;
+      overflow: hidden;
+
+      .avatar {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .defaultAvatar {
+        @include flex-center;
+        background: $ligray;
+        width: 100%;
+        height: 100%;
+      }
+    }
+
+    .userInfo {
+      flex: 1;
+
+      .statusMessage {
+        @include font-sm;
+        color: $text-muted;
+        margin-bottom: 2px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 150px;
+      }
+
+      .userName {
+        margin: 0 0 0.25rem 0;
+        @include font-md-title;
+        color: $text-dark;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 150px;
+      }
+
+      .userStats {
+        margin-bottom: 2px;
+        @include font-body;
+        color: $text-muted;
+
+        span {
+          font-weight: 700;
+          color: $blue;
+          margin-left: 0.2rem;
+        }
+      }
+
+      .date {
+        @include font-sm;
+        color: $text-muted;
+      }
+    }
+  }
 }

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,15 +1,71 @@
 'use client';
 
+import Link from 'next/link';
+import Image from 'next/image';
+
 import styles from './Members.module.scss';
 
+import Loading from '@/components/shared/Loading/Loading';
 import NavBar from '@/components/shared/NavBar/NavBar';
 
+import { useUsers } from '@/hooks/useUsers';
+
+import { formatDate } from '@/utils/dateUtils';
+
 export default function MembersPage() {
+  const { users, loading } = useUsers();
+
+  if (loading)
+    return <Loading fullHeight={true} message='울끈불끈이들 입장 중!' />;
+
   return (
     <div className={styles.membersContainer}>
       <NavBar href='/' label='대시보드로 돌아가기' />
 
       <h1 className={styles.title}>🔥 울끈불끈이들 🔥</h1>
+
+      <div className={styles.userGrid}>
+        {users.map((user) => (
+          <Link
+            href={`/members/${user.id}`}
+            key={user.id}
+            className={styles.userCard}
+          >
+            <div className={styles.avatarWrapper}>
+              {user.avatar_url ? (
+                <Image
+                  src={user.avatar_url}
+                  alt={user.nickname}
+                  width={50}
+                  height={50}
+                  className={styles.avatar}
+                />
+              ) : (
+                <div className={styles.defaultAvatar}>💪</div>
+              )}
+            </div>
+            <div className={styles.userInfo}>
+              <p className={styles.statusMessage}>{user.status_message}</p>
+
+              <h3 className={styles.userName}>{user.nickname}</h3>
+
+              <p className={styles.userStats}>
+                PR{' '}
+                <span>
+                  {user.max_total && user.max_total > 0
+                    ? `${user.max_total}kg`
+                    : '기록 없음'}
+                </span>
+              </p>
+
+              <p className={styles.date}>
+                마지막 기록{''}
+                <span> {formatDate(user.last_activity)}</span>
+              </p>
+            </div>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### 작업 내용
- `useUsers` 훅 사용하여 실제 멤버 데이터 리스트 렌더링
- 로딩 상태 시 `Loading` 컴포넌트 표시 (울끈불끈이들 입장 중!)
- 유저 아바타, 닉네임, 상태메시지, PR 기록, 마지막 활동 날짜 표시
- 각 유저 클릭 시 `/members/[id]` 페이지로 이동
