### PR TITLE
feat: 멤버 상세 페이지 기능 구현

### DIFF
--- a/src/app/members/[id]/MemberDetail.module.scss
+++ b/src/app/members/[id]/MemberDetail.module.scss
@@ -1,0 +1,66 @@
+@use '../../../styles' as *;
+
+.MemberDetailContainer {
+  max-width: 900px;
+  margin: 0 auto;
+
+  .header {
+    width: 100%;
+
+    .navGroup {
+      @include flex-center;
+
+      position: relative;
+      width: 100%;
+      min-height: 80px;
+
+      @media (max-width: 768px) {
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 10px;
+        min-height: auto;
+        padding: 1.5rem 0;
+
+        & > div {
+          width: auto;
+          margin: 0;
+        }
+
+        & > div:nth-child(1) {
+          order: 1;
+        }
+
+        & > div:nth-child(3) {
+          order: 2;
+        }
+
+        .title {
+          order: 3;
+          width: 100%;
+          margin-top: 1rem;
+          white-space: normal;
+          text-align: center;
+        }
+      }
+    }
+
+    .title {
+      @include font-lg-title;
+      text-align: center;
+      gap: 8px;
+      white-space: nowrap;
+
+      strong {
+        color: $blue;
+      }
+    }
+  }
+
+  .contents {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 20px;
+  }
+}

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import styles from './MemberDetail.module.scss';
+
+import RecordChart from '@/components/RecordChart/RecordChart';
+import RecordList from '@/components/RecordList/RecordList';
+import ProfileCard from '@/components/Profile';
+
+import NavBar from '@/components/shared/NavBar/NavBar';
+import Empty from '@/components/shared/Empty/Empty';
+
+import { useProfile } from '@/hooks/useProfile';
+
+export default function MemberDetailPage() {
+  const params = useParams();
+  const userId = params?.id as string;
+
+  const { profile, loading } = useProfile(userId);
+
+  if (!userId) return <Empty message='유저 정보를 찾을 수 없습니다.' />;
+
+  return (
+    <div className={styles.MemberDetailContainer}>
+      <header className={styles.header}>
+        <div className={styles.navGroup}>
+          <NavBar href='/members' label='뒤로가기' />
+          <h1 className={styles.title}>
+            {loading ? (
+              '울끈불끈이 입장 중!'
+            ) : (
+              <>
+                <strong className={styles.nickname}>{profile?.nickname}</strong>{' '}
+                님의 상세 기록
+              </>
+            )}
+          </h1>
+          <NavBar href='/' label='대시보드로 돌아가기' />
+        </div>
+      </header>
+
+      <div className={styles.contents}>
+        <ProfileCard userId={userId} readOnly={true} />
+        <RecordChart userId={userId} />
+        <RecordList userId={userId} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### 작업 내용
- `useParams`로 `userId`를 받아 사용자 데이터 렌더링
- 프로필 카드, 기록 차트, 기록 리스트 컴포넌트 연결
- 로딩 상태 및 유효하지 않은 유저에 대한 예외 처리