### PR TITLE
feat: 외부 이미지 도메인 설정 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,19 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+      },
+      {
+        protocol: 'https',
+        hostname: '*.supabase.co',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
### 작업 내용
- `next.config.ts`에 `images.remotePatterns` 설정 추가
- `lh3.googleusercontent.com` 도메인 이미지 로드 허용
- `*.supabase.co` 도메인 이미지 로드 허용