### PR TITLE
feat: 프로필 카드 UI 및 구조/상태 로직 개선

### DIFF
--- a/src/components/Profile/Profile.module.scss
+++ b/src/components/Profile/Profile.module.scss
@@ -1,6 +1,6 @@
 @use '../../styles' as *;
 
-.profileWrapper {
+.profileContainer {
   width: 100%;
   border-radius: 16px;
   overflow: hidden;
@@ -10,19 +10,12 @@
   position: relative;
   min-height: 700px;
 
-  @media (max-width: 720px) {
+  @media (max-width: 768px) {
     min-height: 600px;
   }
 }
 
-.characterSection {
-  @include flex-center;
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(to bottom, #e3f2fd, #ffffff);
-}
-
-.infoCard {
+.infoSection {
   position: absolute;
   left: 0;
   right: 0;
@@ -30,155 +23,89 @@
   background: $white;
   border-radius: 24px 24px 0 0;
   box-shadow: $shadow-lg;
-  transition: height 0.4s cubic-bezier(0.32, 0.72, 0, 1);
+  display: grid;
+  grid-template-rows: auto 0fr;
+  transition: grid-template-rows 0.4s cubic-bezier(0.32, 0.72, 0, 1);
   overflow: hidden;
-  align-items: center;
 
-  &.stage1 {
-    height: 160px;
+  &.stage2,
+  &.isEditing {
+    grid-template-rows: auto 1fr;
   }
 
-  &.stage2 {
-    height: 420px;
-  }
-
-  .handle {
-    display: flex;
-    justify-content: center;
-    padding: 12px 0 4px;
+  .infoHeader {
+    grid-row: 1;
     cursor: pointer;
-    user-select: none;
-    -webkit-tap-highlight-color: transparent;
+    padding-bottom: 8px;
 
-    .handleBar {
-      width: 40px;
-      height: 4px;
-      border-radius: 2px;
-      background: $ligray;
-      transition: background 0.2s;
-
-      .handle:active & {
-        background: $ligray-hover;
-      }
-    }
-  }
-}
-
-.profileContent {
-  padding: 24px 24px;
-}
-
-.editContainer,
-.infoContainer {
-  @include flex-center;
-  gap: 20px;
-}
-
-.avatarWrapper {
-  position: relative;
-  width: 85px;
-  height: 85px;
-  border-radius: 50%;
-  background: $white;
-  overflow: hidden;
-  flex-shrink: 0;
-
-  &.editable {
-    cursor: pointer;
-    &:hover .avatarOverlay {
-      opacity: 1;
-    }
-  }
-
-  .avatar {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-
-  .avatarOverlay {
-    @include flex-center;
-    @include font-sm;
-    font-weight: 500;
-    position: absolute;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.4);
-    color: $white;
-    opacity: 0;
-    transition: opacity 0.2s;
-  }
-}
-
-.editBox {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-}
-
-.textGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-
-  .subText {
-    @include font-sm;
-    color: $text-muted;
-  }
-
-  .nickname {
-    @include font-md-title;
-    font-weight: 800;
-    color: $text-dark;
-  }
-}
-
-.nameWrapper {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-
-  .editWrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    width: 100%;
-
-    .statusInput {
-      @include font-sm;
-      border: none;
-      border-bottom: 2px solid $border-liblue;
-      padding: 0 4px;
-      outline: none;
-      color: $text-muted;
-      background: transparent;
-      width: 100%;
-      max-width: 220px;
-
-      &:focus {
-        border-bottom-color: $blue-hover;
-      }
-    }
-
-    .nicknameInput {
-      @include font-md-title;
-      border: none;
-      border-bottom: 2px solid $border-liblue;
-      padding: 0 4px;
-      outline: none;
-      color: $text-dark;
-      background: transparent;
-      width: 100%;
-      max-width: 220px;
-
-      &:focus {
-        border-bottom-color: $blue-hover;
-      }
-    }
-
-    .editBtns {
+    .handle {
       display: flex;
-      gap: 8px;
+      justify-content: center;
+      padding: 12px 0 8px;
+
+      .handleBar {
+        width: 40px;
+        height: 4px;
+        border-radius: 2px;
+        background: $ligray;
+        transition: all 0.2s ease;
+      }
     }
+
+    &:hover .handleBar {
+      background: $ligray-hover;
+      transform: scaleX(1.1);
+    }
+
+    &:active .handleBar {
+      background: $gray;
+      transform: scaleX(1.05) translateY(1px);
+    }
+
+    .infoTitle {
+      padding: 0 24px;
+
+      .infoLoading {
+        @include flex-center;
+        flex-direction: column;
+        width: 100%;
+        min-height: 105px;
+      }
+
+      .editTitle {
+        padding: 14px;
+      }
+    }
+  }
+
+  &.isEditing .infoHeader {
+    cursor: default;
+    pointer-events: none;
+  }
+
+  .infoContent {
+    grid-row: 2;
+    min-height: 0;
+    transition: visibility 0.4s;
+    visibility: hidden;
+
+    .contentBox {
+      padding: 0 24px 15px;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .contentDetails {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+      margin-top: 10px;
+      @include fade-in-anim();
+    }
+  }
+
+  &.stage2 .infoContent,
+  &.isEditing .infoContent {
+    visibility: visible;
   }
 }

--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -1,87 +1,186 @@
 'use client';
 
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import styles from './Profile.module.scss';
 
-import CharacterView from './CharacterView';
-import ProfileEdit from './ProfileEdit';
-import ProfileInfo from './ProfileInfo';
+import CharacterView from './components/CharacterView/CharacterView';
+import ProfileEdit from './components/ProfileEdit/ProfileEdit';
+import ProfileInfo from './components/ProfileInfo/ProfileInfo';
+import StatsSection from './components/StatsSection/StatsSection';
+import ActionsSection from './components/ActionsSection/ActionsSection';
+
+import Loading from '../shared/Loading/Loading';
+import Empty from '../shared/Empty/Empty';
 
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
-
-import Loading from '../shared/Loading/Loading';
+import { useRecords } from '@/hooks/useRecords';
+import { useProfileUpdate } from '@/hooks/useProfileUpdate';
 
 type ProfileCardProps = {
   userId?: string;
   readOnly?: boolean;
 };
 
-type DrawerStage = 1 | 2;
-
 export default function ProfileCard({
   userId,
   readOnly = false,
 }: ProfileCardProps) {
   const { user } = useAuth();
-
   const targetId = userId || user?.id;
-  const { profile, loading, setProfile } = useProfile(targetId);
 
-  const [stage, setStage] = useState<DrawerStage>(1);
+  const { data: profile, isLoading: loading, isFetched } = useProfile(targetId);
+  const { records, loading: recordsLoading } = useRecords(targetId);
+  const { saveFullProfile } = useProfileUpdate(user!);
+
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [stage, setStage] = useState<1 | 2>(1);
 
   const isMyProfile = !userId || userId === user?.id;
   const canEdit = isMyProfile && user && !readOnly;
 
-  const handleUpdate = (
+  const queryClient = useQueryClient();
+
+  // 프로필 업데이트
+  const handleUpdate = async (
     nickname: string,
     avatar_url: string,
     status_message: string,
   ) => {
-    if (setProfile) {
-      setProfile({ nickname, avatar_url, status_message });
+    if (!profile) return;
+    const success = await saveFullProfile(
+      nickname,
+      status_message,
+      avatar_url,
+      profile.is_public,
+    );
+
+    if (success) {
+      queryClient.invalidateQueries({ queryKey: ['profile', targetId] });
+      setIsEditing(false);
+    }
+  };
+
+  // 공개/비공개
+  const handleTogglePublic = async () => {
+    if (!profile || !canEdit) return;
+
+    const nextPublicStatus = !profile.is_public;
+
+    const confirmMessage = nextPublicStatus
+      ? '내 기록을 공유하고 함께 운동해볼까요?'
+      : '내 기록을 비밀로 유지할까요?';
+
+    if (!confirm(confirmMessage)) return;
+
+    const success = await saveFullProfile(
+      profile.nickname,
+      profile.status_message,
+      profile.avatar_url,
+      nextPublicStatus,
+    );
+
+    if (success) {
+      queryClient.invalidateQueries({ queryKey: ['profile', targetId] });
+
+      alert(
+        nextPublicStatus
+          ? '프로필이 전체 공개로 설정되었습니다.'
+          : '프로필이 비공개로 설정되었습니다.',
+      );
     }
   };
 
   const cycleStage = () => {
-    if (readOnly) return;
+    if (isEditing) return;
     setStage((prev) => (prev === 1 ? 2 : 1));
   };
 
-  if (loading) return <Loading message='프로필 정보를 불러오고 있어요!' />;
-  if (!profile) return <Loading message='프로필 정보를 불러올 수 없습니다.' />;
+  // 공유
+  const handleShare = async () => {
+    if (!profile) return;
+    const shareData = {
+      title: `${profile.nickname}님의 프로필`,
+      text: profile.status_message,
+      url: window.location.href,
+    };
+    try {
+      if (navigator.share) await navigator.share(shareData);
+      else {
+        await navigator.clipboard.writeText(window.location.href);
+        alert('프로필 링크가 클립보드에 복사되었습니다!');
+      }
+    } catch (error) {
+      console.error('공유 실패:', error);
+    }
+  };
+
+  if (isFetched && !loading && !profile)
+    return <Empty message='프로필 정보를 불러올 수 없어요.' />;
 
   return (
-    <div className={styles.profileWrapper}>
+    <div className={styles.profileContainer}>
       <div className={styles.characterSection}>
-        <CharacterView />
+        <CharacterView isLoading={loading} />
       </div>
 
-      <div className={`${styles.infoCard} ${styles[`stage${stage}`]}`}>
-        <div
-          className={styles.handle}
-          onClick={!readOnly ? cycleStage : undefined}
-        >
-          {!readOnly && <div className={styles.handleBar} />}
+      <div
+        className={`${styles.infoSection} ${styles[`stage${stage}`]} ${isEditing ? styles.isEditing : ''}`}
+      >
+        <div className={styles.infoHeader} onClick={cycleStage}>
+          {!isEditing && (
+            <div className={styles.handle}>
+              <div className={styles.handleBar} />
+            </div>
+          )}
+
+          <div className={styles.infoTitle}>
+            {loading ? (
+              <div className={styles.infoLoading}>
+                <Loading size='sm' message='프로필 정보를 불러오고 있어요!' />
+              </div>
+            ) : isEditing ? (
+              <div className={styles.editTitle} />
+            ) : profile ? (
+              <ProfileInfo
+                nickname={profile.nickname}
+                avatarUrl={profile.avatar_url}
+                status={profile.status_message}
+              />
+            ) : null}
+          </div>
         </div>
 
-        <div className={styles.profileContent}>
-          {canEdit ? (
-            <ProfileEdit
-              user={user}
-              initialNickname={profile.nickname}
-              initialAvatar={profile.avatar_url || ''}
-              initialStatus={profile.status_message || ''}
-              onUpdate={handleUpdate}
-            />
-          ) : (
-            <ProfileInfo
-              nickname={profile.nickname}
-              avatarUrl={profile.avatar_url || ''}
-              status={profile.status_message || ''}
-            />
-          )}
+        <div className={styles.infoContent}>
+          <div className={styles.contentBox}>
+            {isEditing && profile ? (
+              <ProfileEdit
+                user={user!}
+                initialNickname={profile.nickname}
+                initialAvatar={profile.avatar_url}
+                initialStatus={profile.status_message}
+                initialIsPublic={profile.is_public}
+                onUpdate={handleUpdate}
+                onEditingChange={setIsEditing}
+              />
+            ) : (
+              <div className={styles.contentDetails}>
+                <StatsSection records={records} loading={recordsLoading} />
+                <ActionsSection
+                  onShare={handleShare}
+                  onEditProfile={() => {
+                    setStage(2);
+                    setIsEditing(true);
+                  }}
+                  onTogglePublic={handleTogglePublic}
+                  isPublic={profile?.is_public}
+                  readOnly={!canEdit}
+                />
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { supabase } from '@/lib/supabase';
 
@@ -6,45 +6,34 @@ export type ProfileData = {
   nickname: string;
   avatar_url: string;
   status_message: string;
+  is_public: boolean;
 };
 
 export function useProfile(userId: string | undefined) {
-  const [profile, setProfile] = useState<ProfileData | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
+  return useQuery({
+    queryKey: ['profile', userId],
+    queryFn: async (): Promise<ProfileData | null> => {
+      if (!userId) return null;
 
-  const fetchProfile = useCallback(async () => {
-    if (!userId) {
-      setLoading(false);
-      return;
-    }
-
-    try {
-      setLoading(true);
       const { data, error } = await supabase
         .from('profiles')
-        .select('nickname, avatar_url, status_message')
+        .select('nickname, avatar_url, status_message, is_public')
         .eq('id', userId)
         .single();
 
       if (error) throw error;
-      setProfile(data as ProfileData);
-    } catch (e) {
-      const error = e as Error;
-      console.error('프로필 로드 실패:', error.message);
-      setProfile(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [userId]);
 
-  useEffect(() => {
-    fetchProfile();
-  }, [fetchProfile]);
+      return {
+        nickname: data.nickname || '울끈불끈이',
 
-  return {
-    profile,
-    loading,
-    setProfile,
-    refreshProfile: fetchProfile,
-  };
+        avatar_url:
+          data.avatar_url && data.avatar_url.trim() !== ''
+            ? data.avatar_url
+            : undefined,
+        status_message: data.status_message || '울끈불끈!',
+        is_public: data.is_public ?? true,
+      };
+    },
+    enabled: !!userId,
+  });
 }


### PR DESCRIPTION
### 작업 내용
- `ProfileCard` 구조를 components/ 하위 디렉터리로 분리하여 개별 컴포넌트로 정리
- `isEditing` 상태와 `stage` 개념을 추가해 편집/상세 보기 전환 UX 개선
- `StatsSection`, `ActionsSection`을 분리해 프로필 카드 내 기록 통계와 공유/편집/공개 토글 기능을 체계화
- 프로필 공개/비공개 설정 및 토글 로직 추가
- 프로필 공유 기능 및 클립보드 복사 대체 로직 구현
- 레이아웃을 `height` 기반에서 `grid-template-rows` 기반으로 개선
- `.infoSection`을 `grid`로 재구조화하고 `stage1`/`stage2`/`isEditing`에 따른 열리기·숨기기 동작을 `visibility`와 `transition`으로 정교화
- 에러/로딩 상태를 `Empty`, `Loading` 컴포넌트로 처리하여 UX 일관성 강화