### PR TITLE
feat: 멤버 상세 페이지 비공개 프로필 접근 제어 추가

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
 import styles from './MemberDetail.module.scss';
 
@@ -12,14 +13,27 @@ import NavBar from '@/components/shared/NavBar/NavBar';
 import Empty from '@/components/shared/Empty/Empty';
 
 import { useProfile } from '@/hooks/useProfile';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function MemberDetailPage() {
   const params = useParams();
+  const router = useRouter();
   const userId = params?.id as string;
 
-  const { profile, loading } = useProfile(userId);
+  const { user: currentUser } = useAuth();
+  const { data: profile, isLoading: loading } = useProfile(userId);
+
+  const isMyPage = currentUser?.id === userId;
+
+  useEffect(() => {
+    if (!loading && profile && !isMyPage && profile.is_public === false) {
+      alert('비공개 설정된 사용자입니다.');
+      router.push('/members');
+    }
+  }, [loading, profile, isMyPage, router]);
 
   if (!userId) return <Empty message='유저 정보를 찾을 수 없습니다.' />;
+  if (!isMyPage && profile?.is_public === false) return null;
 
   return (
     <div className={styles.MemberDetailContainer}>


### PR DESCRIPTION
### 작업 내용
- 멤버 상세 페이지에서 현재 사용자와 대상 사용자를 비교하도록 수정
- 비공개 설정된 프로필은 본인만 접근 가능하도록 처리
- 비공개 프로필 접근 시 members 목록으로 리다이렉트 처리
- 비공개 페이지 진입 방지를 위해 조건부 렌더링 추가