### PR TITLE
refactor: 운동 기록 기능 리팩토링 및 React Query 전환

### DIFF
--- a/src/components/RecordChart/RecordChart.tsx
+++ b/src/components/RecordChart/RecordChart.tsx
@@ -19,6 +19,8 @@ import {
 
 import styles from './RecordChart.module.scss';
 
+import { StrengthRecord } from '@/types/record';
+
 import Button from '../shared/Button/Button';
 import Empty from '../shared/Empty/Empty';
 import Loading from '../shared/Loading/Loading';
@@ -26,8 +28,6 @@ import Loading from '../shared/Loading/Loading';
 import { useRecords } from '@/hooks/useRecords';
 import { useProfile } from '@/hooks/useProfile';
 import { useAuth } from '@/hooks/useAuth';
-
-import { StrengthRecord } from '@/types/record';
 
 type RecordChartProps = {
   userId?: string;
@@ -42,6 +42,7 @@ type ChartPart = {
 type CustomTooltipProps = {
   active?: boolean;
   payload?: Payload<ValueType, NameType>[];
+  activePart: ChartPart;
 };
 
 type ChartDataPoint = StrengthRecord & {
@@ -57,19 +58,32 @@ const PARTS: ChartPart[] = [
   { key: 'ohp', label: 'OHP', color: '#A855F7' },
 ];
 
+const CustomTooltip = ({ active, payload, activePart }: CustomTooltipProps) => {
+  if (active && payload && payload.length) {
+    const point = payload[0].payload as ChartDataPoint;
+    return (
+      <div className={styles.customTooltip}>
+        <p className={styles.tooltipDate}>{point.fullDate}</p>
+        <p className={styles.tooltipValue} style={{ color: payload[0].color }}>
+          {`${activePart.label}: ${payload[0].value}kg`}
+        </p>
+      </div>
+    );
+  }
+  return null;
+};
+
 export default function RecordChart({ userId }: RecordChartProps) {
   const { user } = useAuth();
-
   const targetId = userId || user?.id;
 
-  const { records, loading: recordsLoading } = useRecords(targetId);
-  const { profile, loading: profileLoading } = useProfile(targetId);
+  const { data: records = [], isLoading: recordsLoading } =
+    useRecords(targetId);
+  const { data: profile, isLoading: profileLoading } = useProfile(targetId);
 
   const [activePart, setActivePart] = useState<ChartPart>(PARTS[0]);
-
   const isReadOnly = !!userId;
-
-  const displayName = profile?.nickname || (isReadOnly ? '불끈이' : '울끈이');
+  const displayName = profile?.nickname || '';
 
   const isPageLoading = recordsLoading || (isReadOnly && profileLoading);
 
@@ -96,35 +110,21 @@ export default function RecordChart({ userId }: RecordChartProps) {
       });
   }, [records, activePart]);
 
-  const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
-    if (active && payload && payload.length) {
-      const point = payload[0].payload as ChartDataPoint;
-      return (
-        <div className={styles.customTooltip}>
-          <p className={styles.tooltipDate}>{point.fullDate}</p>
-          <p
-            className={styles.tooltipValue}
-            style={{ color: payload[0].color }}
-          >
-            {`${activePart.label}: ${payload[0].value}kg`}
-          </p>
-        </div>
-      );
-    }
-    return null;
-  };
-
   return (
     <div className={styles.chartContainer}>
       <h1>
-        <strong>{displayName}</strong> 님의 성장 곡선
+        {displayName && (
+          <>
+            <strong>{displayName}</strong> 님의{' '}
+          </>
+        )}
+        성장 곡선
       </h1>
 
       {!isPageLoading && records.length >= 2 && (
         <div className={styles.btnGroup}>
           {PARTS.map((part) => {
             const isActive = activePart.key === part.key;
-
             return (
               <Button
                 key={part.key}
@@ -192,7 +192,7 @@ export default function RecordChart({ userId }: RecordChartProps) {
                 unit='kg'
                 width={45}
               />
-              <Tooltip content={<CustomTooltip />} />
+              <Tooltip content={<CustomTooltip activePart={activePart} />} />
               <Line
                 name={activePart.label}
                 type='monotone'

--- a/src/components/RecordForm/RecordForm.tsx
+++ b/src/components/RecordForm/RecordForm.tsx
@@ -1,91 +1,66 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
+
 import styles from './RecordForm.module.scss';
 
 import Button from '../shared/Button/Button';
+
 import { useRecordForm } from '@/hooks/useRecordForm';
+
 import { blockInvalidNumberChars, stopWheelChange } from '@/utils/inputUtils';
 
+const FIELDS = [
+  { name: 'squat', label: '스쿼트 (kg)', required: true },
+  { name: 'deadlift', label: '데드리프트 (kg)', required: true },
+  { name: 'bench_press', label: '벤치프레스 (kg)', required: true },
+  { name: 'ohp', label: 'OHP (kg)', required: false },
+];
+
 export default function RecordForm() {
-  const { user, record, total, handleChange, handleSubmit } = useRecordForm();
+  const queryClient = useQueryClient();
+
+  const { user, record, total, handleChange, handleSubmit } = useRecordForm({
+    onSuccess: () => {
+      alert('오늘의 득근 완료! 🔥');
+
+      if (user?.id) {
+        queryClient.invalidateQueries({ queryKey: ['records', user.id] });
+      }
+    },
+    onError: (message) => {
+      alert(`저장 실패: ${message}`);
+    },
+  });
 
   return (
     <div className={styles.formContainer}>
       <h1>💪 울끈불끈 기록</h1>
-
       <form onSubmit={handleSubmit}>
-        {/* 필수 입력 */}
-        <div className={styles.inputGroup}>
-          <label>스쿼트 (kg)</label>
-          <input
-            type='number'
-            name='squat'
-            inputMode='numeric'
-            onKeyDown={blockInvalidNumberChars}
-            onWheel={stopWheelChange}
-            value={record.squat}
-            onChange={handleChange}
-            onFocus={(e) => e.target.select()}
-            placeholder='0'
-            required
-            disabled={!user}
-          />
-        </div>
+        {FIELDS.map(({ name, label, required }) => (
+          <div key={name} className={styles.inputGroup}>
+            <label>{label}</label>
+            <input
+              type='number'
+              name={name}
+              inputMode='numeric'
+              onKeyDown={blockInvalidNumberChars}
+              onWheel={stopWheelChange}
+              value={record[name as keyof typeof record]}
+              onChange={handleChange}
+              onFocus={(e) => e.target.select()}
+              placeholder={required ? '0' : '선택 입력 사항'}
+              required={required}
+              disabled={!user}
+            />
+            {name === 'ohp' && (
+              <label className={styles.ohpdec}>
+                * OHP 기록은 합계에 포함되지 않습니다.
+              </label>
+            )}
+          </div>
+        ))}
 
-        <div className={styles.inputGroup}>
-          <label>데드리프트 (kg)</label>
-          <input
-            type='number'
-            name='deadlift'
-            inputMode='numeric'
-            onKeyDown={blockInvalidNumberChars}
-            onWheel={stopWheelChange}
-            value={record.deadlift}
-            onChange={handleChange}
-            onFocus={(e) => e.target.select()}
-            placeholder='0'
-            required
-            disabled={!user}
-          />
-        </div>
-
-        <div className={styles.inputGroup}>
-          <label>벤치프레스 (kg)</label>
-          <input
-            type='number'
-            name='bench_press'
-            inputMode='numeric'
-            onKeyDown={blockInvalidNumberChars}
-            onWheel={stopWheelChange}
-            value={record.bench_press}
-            onChange={handleChange}
-            onFocus={(e) => e.target.select()}
-            placeholder='0'
-            required
-            disabled={!user}
-          />
-        </div>
-
-        {/* 선택 입력 */}
-        <div className={styles.inputGroup}>
-          <label>OHP (kg)</label>
-          <input
-            name='ohp'
-            type='number'
-            inputMode='numeric'
-            onKeyDown={blockInvalidNumberChars}
-            onWheel={stopWheelChange}
-            value={record.ohp}
-            onChange={handleChange}
-            placeholder='선택 입력 사항'
-            disabled={!user}
-          />
-          <label className={styles.ohpdec}>
-            * OHP 기록은 합계에 포함되지 않습니다.
-          </label>
-        </div>
-
-        {/* 합계 */}
         <div className={`${styles.inputGroup} ${styles.totalGroup}`}>
           <label>총 합계 (Total kg)</label>
           <input

--- a/src/components/RecordList/RecordList.tsx
+++ b/src/components/RecordList/RecordList.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import styles from './RecordList.module.scss';
+
+import { StrengthRecord } from '@/types/record';
 
 import Loading from '../shared/Loading/Loading';
 import Button from '../shared/Button/Button';
@@ -14,39 +17,38 @@ import { useAuth } from '@/hooks/useAuth';
 
 import { formatDate, toInputDate } from '@/utils/dateUtils';
 
-import { StrengthRecord } from '@/types/record';
-
 type RecordListProps = {
   userId?: string;
 };
 
 export default function RecordList({ userId }: RecordListProps) {
+  const queryClient = useQueryClient();
   const { user } = useAuth();
-
   const targetId = userId || user?.id;
 
   const {
-    records,
-    loading: recordsLoading,
+    data: records = [],
+    isLoading: recordsLoading,
     deleteRecord,
     updateRecordDate,
   } = useRecords(targetId);
 
+  const { data: profile, isLoading: profileLoading } = useProfile(targetId);
+
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDate, setEditDate] = useState<string>('');
 
-  const { profile, loading: profileLoading } = useProfile(targetId);
-
   const isReadOnly = !!userId;
-
-  const displayName = profile?.nickname || (isReadOnly ? '불끈이' : '울끈이');
-
+  const displayName = profile?.nickname || '';
   const isPageLoading = recordsLoading || (isReadOnly && profileLoading);
 
   const handleBlur = async (id: string, originalDate: string) => {
     if (toInputDate(originalDate) !== editDate) {
       const success = await updateRecordDate(id, editDate);
-      if (success) setEditingId(null);
+      if (success) {
+        setEditingId(null);
+        queryClient.invalidateQueries({ queryKey: ['records', targetId] });
+      }
     } else {
       setEditingId(null);
     }
@@ -57,17 +59,19 @@ export default function RecordList({ userId }: RecordListProps) {
     id: string,
     originalDate: string,
   ) => {
-    if (e.key === 'Enter') {
-      handleBlur(id, originalDate);
-    } else if (e.key === 'Escape') {
-      setEditingId(null);
-    }
+    if (e.key === 'Enter') handleBlur(id, originalDate);
+    else if (e.key === 'Escape') setEditingId(null);
   };
 
   return (
     <div className={styles.listContainer}>
       <h1>
-        <strong>{displayName}</strong> 님의 기록 히스토리
+        {displayName && (
+          <>
+            <strong>{displayName}</strong> 님의{' '}
+          </>
+        )}
+        기록 히스토리
       </h1>
 
       <div className={styles.contentWrapper}>
@@ -117,11 +121,14 @@ export default function RecordList({ userId }: RecordListProps) {
                         />
                       ) : (
                         <span
-                          onClick={() => {
-                            if (isReadOnly) return;
-                            setEditingId(r.id);
-                            setEditDate(toInputDate(r.created_at));
-                          }}
+                          onClick={
+                            !isReadOnly
+                              ? () => {
+                                  setEditingId(r.id);
+                                  setEditDate(toInputDate(r.created_at));
+                                }
+                              : undefined
+                          }
                           className={
                             isReadOnly ? styles.pureDate : styles.clickableDate
                           }
@@ -136,13 +143,23 @@ export default function RecordList({ userId }: RecordListProps) {
                     <td>{r.bench_press}kg</td>
                     <td>{r.ohp !== null ? `${r.ohp}kg` : '-'}</td>
                     <td className={styles.total}>{r.total_weight}kg</td>
-
                     {!isReadOnly && (
                       <td>
                         <Button
                           variant='red'
                           size='sm'
-                          onClick={() => deleteRecord(r.id)}
+                          onClick={async () => {
+                            if (!confirm('정말 삭제하시겠습니까?')) return;
+                            const success = await deleteRecord(r.id);
+                            if (success) {
+                              // 여기서도 캐시 무효화!
+                              queryClient.invalidateQueries({
+                                queryKey: ['records', targetId],
+                              });
+                            } else {
+                              alert('삭제에 실패했습니다.');
+                            }
+                          }}
                         >
                           삭제
                         </Button>

--- a/src/hooks/useRecordForm.ts
+++ b/src/hooks/useRecordForm.ts
@@ -5,7 +5,15 @@ import { useAuth } from './useAuth';
 import { supabase } from '@/lib/supabase';
 import { RecordFormState } from '@/types/record';
 
-export function useRecordForm() {
+type UseRecordFormOptions = {
+  onSuccess?: () => void;
+  onError?: (message: string) => void;
+};
+
+export function useRecordForm({
+  onSuccess,
+  onError,
+}: UseRecordFormOptions = {}) {
   const { user } = useAuth();
   const [record, setRecord] = useState<RecordFormState>({
     squat: '',
@@ -22,7 +30,6 @@ export function useRecordForm() {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-
     setRecord((prev) => ({
       ...prev,
       [name as keyof RecordFormState]: value,
@@ -31,7 +38,7 @@ export function useRecordForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!user) return alert('로그인이 필요합니다!');
+    if (!user) return;
 
     // DB에 전송할 데이터
     const payload = {
@@ -47,23 +54,15 @@ export function useRecordForm() {
       const { error } = await supabase.from('records').insert([payload]);
       if (error) throw error;
 
-      alert('오늘의 득근 완료! 🔥');
-
       // 초기화
       setRecord({ squat: '', deadlift: '', bench_press: '', ohp: '' });
-      window.location.reload();
+      onSuccess?.();
     } catch (error: unknown) {
       if (error instanceof Error) {
-        alert(`저장 실패: ${error.message}`);
+        onError?.(error.message);
       }
     }
   };
 
-  return {
-    record,
-    total,
-    handleChange,
-    handleSubmit,
-    user,
-  };
+  return { record, total, handleChange, handleSubmit, user };
 }

--- a/src/hooks/useRecords.ts
+++ b/src/hooks/useRecords.ts
@@ -1,18 +1,19 @@
-import { useEffect, useState, useCallback } from 'react';
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
 
 import { supabase } from '@/lib/supabase';
+
 import { StrengthRecord } from '@/types/record';
 
-export function useRecords(userId: string | null = null) {
-  const [records, setRecords] = useState<StrengthRecord[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-
-  // 데이터 가져오기
-  const fetchRecords = useCallback(async () => {
-    try {
-      setLoading(true);
+export function useRecords(userId: string | null | undefined = null) {
+  // 데이터 페칭
+  const query = useQuery({
+    queryKey: ['records', userId],
+    queryFn: async (): Promise<StrengthRecord[]> => {
       let targetId = userId;
 
+      // userId가 인자로 안 들어왔다면 현재 로그인한 유저 ID 확인
       if (!targetId) {
         const {
           data: { user },
@@ -20,7 +21,7 @@ export function useRecords(userId: string | null = null) {
         targetId = user?.id || null;
       }
 
-      if (!targetId) return;
+      if (!targetId) return [];
 
       const { data, error } = await supabase
         .from('records')
@@ -29,26 +30,22 @@ export function useRecords(userId: string | null = null) {
         .order('created_at', { ascending: false });
 
       if (error) throw error;
-      setRecords((data as StrengthRecord[]) || []);
-    } catch (e) {
-      const error = e as Error;
-      console.error('기록 로드 중 에러:', error.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [userId]);
+      return (data as StrengthRecord[]) || [];
+    },
+    // userId가 있거나 인자가 없을 때만 실행
+    enabled: true,
+    staleTime: 1000 * 60 * 5,
+  });
 
-  // 데이터 삭제
-  const deleteRecord = async (id: string): Promise<void> => {
-    if (!confirm('정말 삭제하시겠습니까?')) return;
-
+  // 삭제
+  const deleteRecord = async (id: string): Promise<boolean> => {
     try {
       const { error } = await supabase.from('records').delete().eq('id', id);
       if (error) throw error;
-      await fetchRecords();
+      return true;
     } catch (e) {
-      const error = e as Error;
-      alert(error.message);
+      console.error((e as Error).message);
+      return false;
     }
   };
 
@@ -57,16 +54,16 @@ export function useRecords(userId: string | null = null) {
     id: string,
     editDate: string,
   ): Promise<boolean> => {
-    if (!editDate) return false;
+    if (!editDate || !query.data) return false;
 
     try {
-      const originalRecord = records.find((r) => r.id === id);
+      const originalRecord = query.data.find((r) => r.id === id);
       if (!originalRecord) return false;
 
       const originalTime = new Date(originalRecord.created_at);
       const newDate = new Date(editDate);
 
-      // 상세 시간(시/분/초) 보존
+      // 기존 기록의 시/분/초 유지
       newDate.setHours(
         originalTime.getHours(),
         originalTime.getMinutes(),
@@ -79,23 +76,17 @@ export function useRecords(userId: string | null = null) {
         .eq('id', id);
 
       if (error) throw error;
-      await fetchRecords();
       return true;
     } catch (e) {
-      const error = e as Error;
-      alert(error.message);
+      console.error((e as Error).message);
       return false;
     }
   };
 
-  useEffect(() => {
-    fetchRecords();
-  }, [fetchRecords]);
-
   return {
-    records,
-    loading,
-    refresh: fetchRecords,
+    ...query,
+    records: query.data || [],
+    loading: query.isLoading,
     deleteRecord,
     updateRecordDate,
   };


### PR DESCRIPTION
### 작업 내용
- `useRecordForm`에 `onSuccess`, `onError` 콜백을 추가해 제출 후 처리 분리
- `useRecords`를 React Query 기반으로 변경해 데이터 조회, 캐싱, 로딩 상태 관리 개선
- 기록 저장 후 목록을 자동 갱신하도록 캐시 무효화 처리 추가
- `RecordForm`의 입력 필드를 배열 기반 렌더링으로 정리해 중복 제거
- `RecordChart`의 `Tooltip`을 분리하고 프로필 표시 로직 정리
- `RecordList`에서 수정/삭제 후 캐시 무효화를 추가해 최신 데이터를 반영하도록 개선