### PR TITLE
feat: 멤버 목록 페이지 리팩터링 및 정렬 로직 추가

### DIFF
--- a/src/app/members/Members.module.scss
+++ b/src/app/members/Members.module.scss
@@ -1,11 +1,11 @@
 @use '../../styles' as *;
 
 .membersContainer {
-  max-width: 800px;
+  max-width: 900px;
   margin: 0 auto;
 
   .title {
-    @include font-lg-title;
+    @include font-xl-title;
     margin-bottom: 2rem;
     color: $text-dark;
     text-align: center;
@@ -17,89 +17,8 @@
     gap: 1rem;
     margin: 20px;
 
-    @media (min-width: 600px) {
+    @media (min-width: 768px) {
       grid-template-columns: repeat(2, 1fr);
-    }
-
-    .userCard {
-      @include flex-center;
-      padding: 1.25rem;
-      background-color: $white;
-      border-radius: $radius-main;
-      border: 1px solid $border-soft;
-      text-decoration: none;
-      color: inherit;
-      transition: $transition-base;
-      position: relative;
-
-      &:hover {
-        transform: $lift-sm;
-        border-color: $blue;
-        box-shadow: 0 4px 12px rgba(0, 123, 255, 0.2);
-      }
-    }
-
-    .avatarWrapper {
-      @include flex-center;
-      width: 50px;
-      height: 50px;
-      margin-right: 1.5rem;
-      border-radius: 50%;
-      overflow: hidden;
-
-      .avatar {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
-      .defaultAvatar {
-        @include flex-center;
-        background: $ligray;
-        width: 100%;
-        height: 100%;
-      }
-    }
-
-    .userInfo {
-      flex: 1;
-
-      .statusMessage {
-        @include font-sm;
-        color: $text-muted;
-        margin-bottom: 2px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        max-width: 150px;
-      }
-
-      .userName {
-        margin: 0 0 0.25rem 0;
-        @include font-md-title;
-        color: $text-dark;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        max-width: 150px;
-      }
-
-      .userStats {
-        margin-bottom: 2px;
-        @include font-body;
-        color: $text-muted;
-
-        span {
-          font-weight: 700;
-          color: $blue;
-          margin-left: 0.2rem;
-        }
-      }
-
-      .date {
-        @include font-sm;
-        color: $text-muted;
-      }
     }
   }
 }

--- a/src/app/members/components/UserCard/UserCard.module.scss
+++ b/src/app/members/components/UserCard/UserCard.module.scss
@@ -1,0 +1,105 @@
+@use '../../../../styles' as *;
+
+.userCard {
+  @include flex-center;
+  padding: 1.25rem;
+  background-color: $white;
+  border-radius: $radius-main;
+  border: 1px solid $border-soft;
+  text-decoration: none;
+  color: inherit;
+  transition: $transition-base;
+  position: relative;
+
+  &:hover {
+    transform: $lift-sm;
+    border-color: $blue;
+    box-shadow: 0 4px 12px rgba(0, 123, 255, 0.2);
+  }
+}
+
+.avatarWrapper {
+  @include flex-center;
+  width: 85px;
+  height: 85px;
+  margin-right: 1.5rem;
+  border-radius: 50%;
+  overflow: hidden;
+
+  .avatar {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .defaultAvatar {
+    @include flex-center;
+    background: $ligray;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.userInfo {
+  flex: 1;
+
+  .statusMessage {
+    @include font-sm;
+    color: $text-muted;
+    margin-bottom: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 150px;
+  }
+
+  .userName {
+    margin: 0 0 0.25rem 0;
+    @include font-lg-title;
+    color: $text-dark;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 150px;
+  }
+
+  .userStats {
+    margin-bottom: 2px;
+    @include font-body;
+    color: $text-muted;
+
+    span {
+      font-weight: 700;
+      color: $blue;
+      margin-left: 0.2rem;
+    }
+  }
+
+  .date {
+    @include font-sm;
+    color: $text-muted;
+
+    span {
+      margin-left: 0.2rem;
+    }
+  }
+}
+
+.privateCard {
+  filter: grayscale(0.5);
+  opacity: 0.8;
+  pointer-events: none;
+  background: $ligray;
+  border-color: $border-light;
+
+  .lockBadge {
+    @include font-sm;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: $gray;
+    color: $white;
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+}

--- a/src/app/members/components/UserCard/UserCard.tsx
+++ b/src/app/members/components/UserCard/UserCard.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+import Image from 'next/image';
+
+import styles from './UserCard.module.scss';
+
+import { UserSummary } from '@/types/user';
+
+import { formatDate } from '@/utils/dateUtils';
+import { getDisplayDate, getCombinedTotalFromUser } from '@/utils/recordUtils';
+
+type UserCardProps = {
+  user: UserSummary;
+};
+
+export default function UserCard({ user }: UserCardProps) {
+  const isPrivate = user.is_public === false;
+
+  const cardContent = (
+    <>
+      <div className={styles.avatarWrapper}>
+        {user.avatar_url ? (
+          <Image
+            src={user.avatar_url}
+            alt={user.nickname}
+            width={85}
+            height={85}
+            className={styles.avatar}
+            unoptimized
+          />
+        ) : (
+          <div className={styles.defaultAvatar}>💪</div>
+        )}
+      </div>
+
+      <div className={styles.userInfo}>
+        <p className={styles.statusMessage}>{user.status_message}</p>
+        <h3 className={styles.userName}>{user.nickname}</h3>
+        <p className={styles.userStats}>
+          PR:<span>{getCombinedTotalFromUser(user)}</span>
+        </p>
+        <p className={styles.date}>
+          마지막 기록:
+          <span>
+            {getDisplayDate(user.is_public, user.last_activity, formatDate)}
+          </span>
+        </p>
+      </div>
+    </>
+  );
+
+  if (isPrivate) {
+    return (
+      <div className={`${styles.userCard} ${styles.privateCard}`}>
+        <div className={styles.lockBadge}>🔒 비공개</div>
+        {cardContent}
+      </div>
+    );
+  }
+
+  return (
+    <Link href={`/members/${user.id}`} className={styles.userCard}>
+      {cardContent}
+    </Link>
+  );
+}

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,19 +1,34 @@
 'use client';
 
-import Link from 'next/link';
-import Image from 'next/image';
+import { useMemo } from 'react';
 
 import styles from './Members.module.scss';
+
+import UserCard from './components/UserCard/UserCard';
 
 import Loading from '@/components/shared/Loading/Loading';
 import NavBar from '@/components/shared/NavBar/NavBar';
 
 import { useUsers } from '@/hooks/useUsers';
 
-import { formatDate } from '@/utils/dateUtils';
-
 export default function MembersPage() {
   const { users, loading } = useUsers();
+
+  const sortedUsers = useMemo(() => {
+    return [...users].sort((a, b) => {
+      if (a.is_public !== b.is_public) return a.is_public ? -1 : 1;
+
+      const totalA =
+        (a.max_squat || 0) + (a.max_bench || 0) + (a.max_deadlift || 0);
+      const totalB =
+        (b.max_squat || 0) + (b.max_bench || 0) + (b.max_deadlift || 0);
+
+      const finalA = totalA || a.max_total || 0;
+      const finalB = totalB || b.max_total || 0;
+
+      return finalB - finalA;
+    });
+  }, [users]);
 
   if (loading)
     return <Loading fullHeight={true} message='울끈불끈이들 입장 중!' />;
@@ -21,49 +36,11 @@ export default function MembersPage() {
   return (
     <div className={styles.membersContainer}>
       <NavBar href='/' label='대시보드로 돌아가기' />
-
       <h1 className={styles.title}>🔥 울끈불끈이들 🔥</h1>
 
       <div className={styles.userGrid}>
-        {users.map((user) => (
-          <Link
-            href={`/members/${user.id}`}
-            key={user.id}
-            className={styles.userCard}
-          >
-            <div className={styles.avatarWrapper}>
-              {user.avatar_url ? (
-                <Image
-                  src={user.avatar_url}
-                  alt={user.nickname}
-                  width={50}
-                  height={50}
-                  className={styles.avatar}
-                />
-              ) : (
-                <div className={styles.defaultAvatar}>💪</div>
-              )}
-            </div>
-            <div className={styles.userInfo}>
-              <p className={styles.statusMessage}>{user.status_message}</p>
-
-              <h3 className={styles.userName}>{user.nickname}</h3>
-
-              <p className={styles.userStats}>
-                PR{' '}
-                <span>
-                  {user.max_total && user.max_total > 0
-                    ? `${user.max_total}kg`
-                    : '기록 없음'}
-                </span>
-              </p>
-
-              <p className={styles.date}>
-                마지막 기록{''}
-                <span> {formatDate(user.last_activity)}</span>
-              </p>
-            </div>
-          </Link>
+        {sortedUsers.map((user) => (
+          <UserCard key={user.id} user={user} />
         ))}
       </div>
     </div>

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -2,27 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { supabase } from '@/lib/supabase';
 
-type RawProfile = {
-  id: string;
-  nickname: string | null;
-  avatar_url: string | null;
-  status_message: string | null;
-};
-
-type RawRecord = {
-  user_id: string;
-  total_weight: number | null;
-  created_at: string;
-};
-
-export type UserSummary = {
-  id: string;
-  nickname: string;
-  avatar_url: string;
-  status_message: string;
-  max_total: number;
-  last_activity: string;
-};
+import { UserSummary, ProfileWithRecords } from '@/types/user';
 
 export function useUsers() {
   const [users, setUsers] = useState<UserSummary[]>([]);
@@ -33,63 +13,72 @@ export function useUsers() {
       try {
         setLoading(true);
 
-        // 프로필 정보 가져오기
-        const { data: profiles, error: pError } = await supabase
-          .from('profiles')
-          .select('id, nickname, avatar_url, status_message');
+        const { data, error } = await supabase.from('profiles').select<
+          string,
+          ProfileWithRecords
+        >(`
+            id, 
+            nickname, 
+            avatar_url, 
+            status_message,
+            is_public,
+            records (
+              squat, 
+              bench_press, 
+              deadlift, 
+              total_weight, 
+              created_at
+            )
+          `);
 
-        if (pError) throw pError;
-        const typedProfiles = profiles as RawProfile[];
+        if (error) throw error;
+        if (!data) return;
 
-        // 기록 정보 가져오기
-        const { data: records, error: rError } = await supabase
-          .from('records')
-          .select('user_id, total_weight, created_at');
+        const userList: UserSummary[] = data.map((user) => {
+          const userRecords = user.records || [];
 
-        if (rError) throw rError;
-        const typedRecords = records as RawRecord[];
-
-        // 데이터 조합
-        const userList: UserSummary[] = typedProfiles.map((profile) => {
-          const userRecords = typedRecords.filter(
-            (r) => r.user_id === profile.id,
+          const maxSquat = Math.max(...userRecords.map((r) => r.squat ?? 0), 0);
+          const maxBench = Math.max(
+            ...userRecords.map((r) => r.bench_press ?? 0),
+            0,
+          );
+          const maxDead = Math.max(
+            ...userRecords.map((r) => r.deadlift ?? 0),
+            0,
           );
 
-          const maxTotal =
-            userRecords.length > 0
-              ? Math.max(...userRecords.map((r) => r.total_weight || 0))
-              : 0;
+          const totalPR = maxSquat + maxBench + maxDead;
 
           const lastActivity =
             userRecords.length > 0
-              ? [...userRecords].sort(
-                  (a, b) =>
-                    new Date(b.created_at).getTime() -
-                    new Date(a.created_at).getTime(),
-                )[0].created_at
+              ? userRecords
+                  .map((r) => r.created_at)
+                  .sort(
+                    (a, b) => new Date(b).getTime() - new Date(a).getTime(),
+                  )[0]
               : '';
 
           return {
-            id: profile.id,
-            nickname: profile.nickname || '불끈이',
-            avatar_url: profile.avatar_url || '',
-            status_message: profile.status_message || '안녕하세요!',
-            max_total: maxTotal,
+            id: user.id,
+            nickname: user.nickname || '울끈불끈이',
+            avatar_url: user.avatar_url || '',
+            status_message: user.status_message || '울끈불끈!',
+            max_squat: maxSquat,
+            max_bench: maxBench,
+            max_deadlift: maxDead,
+            max_total: totalPR,
             last_activity: lastActivity,
+            is_public: user.is_public ?? true,
           };
         });
 
-        // PR 높은 순 정렬
-        const sortedList = userList.sort((a, b) => b.max_total - a.max_total);
-        setUsers(sortedList);
+        setUsers(userList);
       } catch (e) {
-        const error = e as Error;
-        console.error('유저 목록 로드 실패:', error.message);
+        console.error('유저 목록 로드 실패:', (e as Error).message);
       } finally {
         setLoading(false);
       }
     }
-
     fetchUsers();
   }, []);
 


### PR DESCRIPTION
### 작업내용 
- 멤버 목록 페이지에서 `UserCard` 컴포넌트로 카드 UI 분리하도록 수정
- `useUsers` 훅에서 세부 PR 기록(squat, bench, deadlift) 계산 및 조인 쿼리 처리
- 회원 목록 공개 여부에 따른 정렬 우선순위 적용하도록 처리
- 회원 목록 페이지에서 `useMemo`를 이용한 성능 최적화된 정렬 로직 추가