### PR TITLE
chore: next-pwa 관련 생성 파일 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@
 /.next/
 /out/
 
+# next-pwa 
+/public/sw.js
+/public/swe-worker-*.js
+/public/workbox-*.js
+
 # production
 /build
 


### PR DESCRIPTION
### 작업 내용
- `next-pwa` 사용 시 생성되는 서비스 워커 및 `workbox` 파일 `gitignore`에 추가
- `public/sw.js` 무시 처리
- `public/swe-worker-*.js` 무시 처리
- `public/workbox-*.js` 무시 처리
- 빌드 시 생성되는 `PWA` 관련 산출물이 저장소에 포함되지 않도록 설정