### PR TITLE
refactor: 운동 기록 유틸 함수 PR 표시 로직 정리

### DIFF
--- a/src/utils/recordUtils.ts
+++ b/src/utils/recordUtils.ts
@@ -2,31 +2,58 @@ import { StrengthRecord } from '@/types/record';
 import { UserSummary } from '@/types/user';
 
 /**
- * 특정 날짜의 연도-주차 정보 반환 함수
+ * 특정 날짜의 ISO 8601 기준 연도-주차 정보 반환
  */
-export const getYearWeek = (dateStr: string) => {
+export const getYearWeek = (dateStr: string): string => {
   const d = new Date(dateStr);
   d.setHours(0, 0, 0, 0);
   d.setDate(d.getDate() + 4 - (d.getDay() || 7));
-  const yearStart = new Date(d.getFullYear(), 0, 1);
+  const isoYear = d.getFullYear();
+  const yearStart = new Date(isoYear, 0, 1);
   const weekNo = Math.ceil(
     ((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
   );
-  return `${d.getFullYear()}-${weekNo}`;
+  return `${isoYear}-W${String(weekNo).padStart(2, '0')}`;
 };
 
 /**
- * 특정 종목의 역대 최고 기록 및 해당 날짜 추출 함수
+ * 두 ISO 주차 문자열이 연속된 주인지 확인
+ */
+const isConsecutiveWeek = (weekA: string, weekB: string): boolean => {
+  const toMonday = (yearWeek: string): Date => {
+    const [year, week] = yearWeek.replace('W', '').split('-').map(Number);
+    const jan4 = new Date(year, 0, 4);
+    const jan4DayOfWeek = jan4.getDay() || 7;
+    const monday = new Date(jan4);
+    monday.setDate(jan4.getDate() - (jan4DayOfWeek - 1) + (week - 1) * 7);
+    return monday;
+  };
+
+  const diff =
+    (toMonday(weekA).getTime() - toMonday(weekB).getTime()) / (86400000 * 7);
+  return diff === 1;
+};
+
+/**
+ * 공개 여부 가드
+ */
+const getPrivacyGuard = (isPublic: boolean | undefined): string | null => {
+  return isPublic === false ? '비공개' : null;
+};
+
+/**
+ * 특정 종목의 역대 최고 기록 및 해당 날짜 추출
  */
 export const getBestRecord = (
   records: StrengthRecord[],
-  key: 'squat' | 'deadlift' | 'bench_press' | 'ohp',
+  key: keyof Pick<StrengthRecord, 'squat' | 'deadlift' | 'bench_press' | 'ohp'>,
 ) => {
   return records.reduce(
     (best, curr) => {
       const currValue = curr[key] ?? 0;
+      const currDate = curr.recorded_at || curr.created_at;
       return currValue > best.value
-        ? { value: currValue, date: curr.created_at }
+        ? { value: currValue, date: currDate }
         : best;
     },
     { value: 0, date: '' },
@@ -34,9 +61,9 @@ export const getBestRecord = (
 };
 
 /**
- * 모든 기록을 통틀어 S, B, D 각각의 최고치를 찾아 합산한 최대 3대 합계 계산 함수
+ * 모든 기록을 통틀어 스쿼트·벤치프레스·데드리프트 각각의 최고치를 합산한 3대 PR 계산
  */
-export const calculateTotalPR = (records: StrengthRecord[]) => {
+export const calculateTotalPR = (records: StrengthRecord[]): number => {
   if (!records || records.length === 0) return 0;
   return (
     getBestRecord(records, 'squat').value +
@@ -46,13 +73,17 @@ export const calculateTotalPR = (records: StrengthRecord[]) => {
 };
 
 /**
- * 주 단위로 끊김 없는 연속 운동 기록 계산 함수
+ * 주 단위로 끊김 없는 연속 운동 기록 계산
  */
-export const calculateWeeklyStreak = (records: StrengthRecord[]) => {
+export const calculateWeeklyStreak = (records: StrengthRecord[]): number => {
   if (!records || records.length === 0) return 0;
 
   const recordedWeeks = [
-    ...new Set(records.map((r) => getYearWeek(r.created_at.slice(0, 10)))),
+    ...new Set(
+      records.map((r) =>
+        getYearWeek((r.recorded_at || r.created_at).slice(0, 10)),
+      ),
+    ),
   ].sort((a, b) => b.localeCompare(a));
 
   const todayStr = new Date().toISOString().slice(0, 10);
@@ -73,57 +104,52 @@ export const calculateWeeklyStreak = (records: StrengthRecord[]) => {
 
   let streak = 1;
   for (let i = startIndex; i < recordedWeeks.length - 1; i++) {
-    const [y1, w1] = recordedWeeks[i].split('-').map(Number);
-    const [y2, w2] = recordedWeeks[i + 1].split('-').map(Number);
-
-    const isConsecutive =
-      (y1 === y2 && w1 - w2 === 1) ||
-      (y1 - y2 === 1 && w1 === 1 && (w2 === 52 || w2 === 53));
-
-    if (isConsecutive) streak++;
-    else break;
+    if (isConsecutiveWeek(recordedWeeks[i], recordedWeeks[i + 1])) {
+      streak++;
+    } else {
+      break;
+    }
   }
   return streak;
 };
 
 /**
- * 공개 여부 및 기록 존재 여부에 따라 PR 합계 텍스트 반환 함수
+ * 공개 여부 및 기록 존재 여부에 따라 PR 합계 텍스트 반환
  */
 export const getDisplayPR = (
   isPublic: boolean | undefined,
   maxTotal: number | null,
-) => {
-  if (isPublic === false) return '비공개';
-  if (!maxTotal || maxTotal === 0) return '기록 없음';
-  return `${maxTotal}kg`;
+): string => {
+  return (
+    getPrivacyGuard(isPublic) ??
+    (!maxTotal || maxTotal === 0 ? '기록 없음' : `${maxTotal}kg`)
+  );
 };
 
 /**
- * 공개 여부에 따라 포맷팅된 마지막 활동일 텍스트 반환 함수
+ * 공개 여부에 따라 포맷팅된 마지막 활동일 텍스트 반환
  */
 export const getDisplayDate = (
   isPublic: boolean | undefined,
   lastActivity: string,
   formatter: (date: string) => string,
-) => {
-  if (isPublic === false) return '비공개';
-  if (!lastActivity) return '없음';
-  return formatter(lastActivity);
+): string => {
+  return (
+    getPrivacyGuard(isPublic) ??
+    (!lastActivity ? '없음' : formatter(lastActivity))
+  );
 };
 
 /**
- * 종목별 최고치를 찾아 합산된 PR 텍스트 반환 함수
+ * UserSummary로부터 3대 합계 텍스트 반환
  */
-export const getCombinedTotalFromUser = (user: UserSummary) => {
-  if (user.is_public === false) return '비공개';
+export const getCombinedTotalFromUser = (user: UserSummary): string => {
+  const guard = getPrivacyGuard(user.is_public);
+  if (guard) return guard;
 
-  const s = user.max_squat || 0;
-  const b = user.max_bench || 0;
-  const d = user.max_deadlift || 0;
-
-  const total = s + b + d;
-
-  if (total === 0 && user.max_total) return `${user.max_total}kg`;
-
-  return total > 0 ? `${total}kg` : '0kg';
+  const total =
+    (user.max_squat ?? 0) + (user.max_bench ?? 0) + (user.max_deadlift ?? 0);
+  if (total > 0) return `${total}kg`;
+  if (user.max_total) return `${user.max_total}kg`;
+  return '기록 없음';
 };


### PR DESCRIPTION
### 작업 내용

- `recorded_at` 우선 사용, fallback으로 `created_at` 사용
- ISO 주차 포맷 통일 및 연속 주차 계산 로직 정리
- 공개 여부 가드 로직 통합
- PR/기록 없음 상태 텍스트 반환값 정리