### PR TITLE
feat: 프로필 이미지 업로드 경로 개선

### DIFF
--- a/src/components/Profile/components/StatsSection/StatsSection.tsx
+++ b/src/components/Profile/components/StatsSection/StatsSection.tsx
@@ -4,12 +4,12 @@ import { useMemo } from 'react';
 
 import styles from './StatsSection.module.scss';
 
-import { StrengthRecord } from '@/types/record';
-
 import Loading from '@/components/shared/Loading/Loading';
 
 import { formatDate } from '@/utils/dateUtils';
 import { getBestRecord, calculateWeeklyStreak } from '@/utils/recordUtils';
+
+import { StrengthRecord } from '@/types/record';
 
 type StatsSectionProps = {
   records: StrengthRecord[];
@@ -63,7 +63,7 @@ export default function StatsSection({ records, loading }: StatsSectionProps) {
         </div>
         <div className={styles.streakBox}>
           <strong className={styles.statValue}>{stats.weeklyStreak}</strong>
-          <label className={styles.statLabel}>주 연속 기록</label>
+          <label className={styles.statLabel}>🔥주 연속 기록🔥</label>
         </div>
       </div>
 
@@ -77,7 +77,6 @@ export default function StatsSection({ records, loading }: StatsSectionProps) {
               {s.value}
               {s.value > 0 && <span>kg</span>}
             </strong>
-
             <span className={styles.recordsDate}>
               {s.date ? formatDate(s.date) : '기록 없음'}
             </span>

--- a/src/hooks/useProfileUpdate.ts
+++ b/src/hooks/useProfileUpdate.ts
@@ -16,14 +16,19 @@ export function useProfileUpdate(user: User) {
 
       // 기존 이미지 삭제
       if (prevAvatarUrl) {
-        const prevFileName = prevAvatarUrl.split('/').pop();
-        if (prevFileName) {
-          await supabase.storage.from('avatar').remove([prevFileName]);
+        // URL에서 폴더명/파일명만 추출
+        const urlParts = prevAvatarUrl.split('/');
+        const fileNameWithFolder = `${urlParts[urlParts.length - 2]}/${urlParts[urlParts.length - 1]}`;
+
+        if (fileNameWithFolder.includes(user.id)) {
+          // 내 폴더의 파일인지 확인
+          await supabase.storage.from('avatar').remove([fileNameWithFolder]);
         }
       }
 
       const fileExt = file.name.split('.').pop();
-      const fileName = `${user.id}-${Date.now()}.${fileExt}`;
+      // 파일명 앞에 유저 ID와 /를 붙여 폴더 지정
+      const fileName = `${user.id}/${Date.now()}.${fileExt}`;
 
       const { error: uploadError } = await supabase.storage
         .from('avatar')
@@ -34,6 +39,7 @@ export function useProfileUpdate(user: User) {
       const {
         data: { publicUrl },
       } = supabase.storage.from('avatar').getPublicUrl(fileName);
+
       return publicUrl;
     } catch (error) {
       console.error('Upload error:', error);


### PR DESCRIPTION
### 작업 내용
- `user.id/타임스탬프.확장자` 형식으로 사용자별 폴더 구조를 만들어 이미지 업로드 경로 개선
- 이전 URL에서 `folder/filename`을 추출해 `user.id`가 포함된 파일만 삭제하도록 로직 개선
- 타 사용자 파일이 삭제되지 않도록 ID 검증 로직을 추가해 안전성 강화