### PR TITLE
feat: 멤버 리스트 정렬 및 페이징 기능 추가

### DIFF
--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,18 +1,22 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import styles from './Members.module.scss';
 
 import UserCard from './components/UserCard/UserCard';
 
+import Pagination from '@/components/shared/Pagination/Pagination';
 import Loading from '@/components/shared/Loading/Loading';
 import NavBar from '@/components/shared/NavBar/NavBar';
 
 import { useUsers } from '@/hooks/useUsers';
 
+const PAGE_SIZE = 8;
+
 export default function MembersPage() {
   const { users, loading } = useUsers();
+  const [currentPage, setCurrentPage] = useState<number>(1);
 
   const sortedUsers = useMemo(() => {
     return [...users].sort((a, b) => {
@@ -30,6 +34,13 @@ export default function MembersPage() {
     });
   }, [users]);
 
+  const paginatedUsers = useMemo(() => {
+    return sortedUsers.slice(
+      (currentPage - 1) * PAGE_SIZE,
+      currentPage * PAGE_SIZE,
+    );
+  }, [sortedUsers, currentPage]);
+
   if (loading)
     return <Loading fullHeight={true} message='울끈불끈이들 입장 중!' />;
 
@@ -39,10 +50,17 @@ export default function MembersPage() {
       <h1 className={styles.title}>🔥 울끈불끈이들 🔥</h1>
 
       <div className={styles.userGrid}>
-        {sortedUsers.map((user) => (
+        {paginatedUsers.map((user) => (
           <UserCard key={user.id} user={user} />
         ))}
       </div>
+
+      <Pagination
+        totalCount={sortedUsers.length}
+        pageSize={PAGE_SIZE}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
     </div>
   );
 }

--- a/src/components/shared/Pagination/Pagination.tsx
+++ b/src/components/shared/Pagination/Pagination.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from 'lucide-react';
 
 import { usePagination, DOTS } from '@/hooks/usePagination';
 
@@ -32,6 +37,17 @@ export default function Pagination({
 
   return (
     <nav aria-label='페이지 탐색' className={styles.pagination}>
+      {/* 맨 앞으로 이동 */}
+      <button
+        onClick={() => onPageChange(1)}
+        disabled={currentPage === 1}
+        className={styles.arrow}
+        aria-label='첫 페이지로 이동'
+      >
+        <ChevronsLeft size={15} />
+      </button>
+
+      {/* 이전 페이지 */}
       <button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
@@ -41,6 +57,7 @@ export default function Pagination({
         <ChevronLeft size={15} />
       </button>
 
+      {/* 페이지 번호 */}
       {pages.map((page, idx) =>
         page === DOTS ? (
           <span key={`dots-${idx}`} className={styles.dots}>
@@ -58,6 +75,7 @@ export default function Pagination({
         ),
       )}
 
+      {/* 다음 페이지 */}
       <button
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage === totalPageCount}
@@ -65,6 +83,16 @@ export default function Pagination({
         aria-label='다음 페이지'
       >
         <ChevronRight size={15} />
+      </button>
+
+      {/* 맨 끝으로 이동 */}
+      <button
+        onClick={() => onPageChange(totalPageCount)}
+        disabled={currentPage === totalPageCount}
+        className={styles.arrow}
+        aria-label='마지막 페이지로 이동'
+      >
+        <ChevronsRight size={15} />
       </button>
     </nav>
   );

--- a/src/hooks/useRecords.ts
+++ b/src/hooks/useRecords.ts
@@ -57,6 +57,7 @@ export function useRecords(userId: string | null | undefined = null) {
     ...query,
     records: query.data || [],
     loading: query.isLoading,
+    isReady: query.isSuccess,
     deleteRecord: deleteMutation.mutateAsync,
     updateRecordDate: (id: string, editDate: string) =>
       updateDateMutation.mutateAsync({ id, editDate }),


### PR DESCRIPTION
### 작업 내용
- `Pagination` 컴포넌트에 맨 앞으로 이동 / 맨 끝으로 이동 버튼 추가
- `MembersPage`에 회원 리스트 정렬 및 페이징 기능 추가 및 8명씩 페이징 처리
- `useRecords` 훅이 반환하는 객체에 `isReady` 플래그 추가
- `isReady`는 내부 query의 `isSuccess`를 기반으로 데이터가 준비되었는지 확인