### PR TITLE
feat: PWA 설치 안내 배너 구현

### DIFF
--- a/src/components/InstallBanner/InstallBanner.module.scss
+++ b/src/components/InstallBanner/InstallBanner.module.scss
@@ -1,0 +1,90 @@
+@use '../../styles' as *;
+
+.bannerContainer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
+  background: $dark;
+  color: $white;
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  box-shadow: $shadow-md;
+
+  .contentWrapper {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: 1;
+
+    .icon {
+      width: 50px;
+      height: 50px;
+      border-radius: 10px;
+      background: $white;
+    }
+
+    .text {
+      strong {
+        display: block;
+        @include font-md-title;
+        margin-bottom: 2px;
+      }
+
+      p {
+        @include font-body;
+        color: $text-muted;
+        margin: 0;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        column-gap: 2px;
+        row-gap: 6px;
+
+        .sharedBtn {
+          color: $blue;
+          flex-shrink: 0;
+          vertical-align: text-bottom;
+          margin: 0 2px;
+        }
+
+        .arrow {
+          color: $text-muted;
+          flex-shrink: 0;
+        }
+
+        strong {
+          display: inline;
+          margin: 0;
+          color: $white;
+          white-space: nowrap;
+        }
+
+        @media (min-width: 768px) {
+          flex-wrap: nowrap;
+        }
+      }
+    }
+  }
+
+  .actionWrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+
+    .dismissButton {
+      @include flex-center;
+      @include font-body;
+      background: transparent;
+      border: none;
+      color: $ligray-text;
+      cursor: pointer;
+      padding: 4px;
+    }
+  }
+}

--- a/src/components/InstallBanner/InstallBanner.tsx
+++ b/src/components/InstallBanner/InstallBanner.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useState, useCallback } from 'react';
+import { SquareArrowUp, ArrowRight, X } from 'lucide-react';
+
+import styles from './InstallBanner.module.scss';
+
+import Button from '../shared/Button/Button';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+const BANNER_DISMISSED_KEY = 'installBannerDismissed';
+
+export default function InstallBanner() {
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [showBanner, setShowBanner] = useState<boolean>(false);
+  const [isIOS, setIsIOS] = useState<boolean>(false);
+
+  useEffect(() => {
+    const isDismissed = localStorage.getItem(BANNER_DISMISSED_KEY);
+    const isStandalone = window.matchMedia(
+      '(display-mode: standalone)',
+    ).matches;
+    if (isDismissed || isStandalone) return;
+
+    const ios =
+      /iphone|ipad|ipod/i.test(navigator.userAgent) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    setIsIOS(ios);
+
+    if (ios) {
+      setShowBanner(true);
+      return;
+    }
+
+    const handleBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setShowBanner(true);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    return () =>
+      window.removeEventListener(
+        'beforeinstallprompt',
+        handleBeforeInstallPrompt,
+      );
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    if (!deferredPrompt) return;
+
+    try {
+      await deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      if (outcome === 'accepted') setShowBanner(false);
+    } catch (e) {
+      console.error('설치 프롬프트 오류:', e);
+    } finally {
+      setDeferredPrompt(null);
+    }
+  }, [deferredPrompt]);
+
+  const handleDismiss = useCallback(() => {
+    setShowBanner(false);
+    localStorage.setItem(BANNER_DISMISSED_KEY, 'true');
+  }, []);
+
+  if (!showBanner) return null;
+
+  return (
+    <div className={styles.bannerContainer}>
+      <div className={styles.contentWrapper}>
+        <Image
+          width={50}
+          height={50}
+          src='/assets/images/muscle.png'
+          alt='앱 아이콘'
+          className={styles.icon}
+        />
+        <div className={styles.text}>
+          <strong>울끈불끈</strong>
+          {isIOS ? (
+            <p>
+              <span>
+                Safari 하단 공유버튼
+                <SquareArrowUp size={16} className={styles.sharedBtn} />
+              </span>
+              <ArrowRight size={16} className={styles.arrow} />
+              <strong>"홈 화면에 추가"</strong>를 누르세요
+            </p>
+          ) : (
+            <p>홈 화면에 추가하고 앱처럼 사용하세요!</p>
+          )}
+        </div>
+      </div>
+      <div className={styles.actionWrapper}>
+        {!isIOS && deferredPrompt && (
+          <Button variant='white' size='md' onClick={handleInstall}>
+            설치
+          </Button>
+        )}
+        <button
+          className={styles.dismissButton}
+          onClick={handleDismiss}
+          aria-label='닫기'
+        >
+          <X size={24} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/Button/Button.module.scss
+++ b/src/components/shared/Button/Button.module.scss
@@ -44,6 +44,15 @@
   }
 }
 
+.white {
+  background-color: $white;
+  color: $text-dark;
+
+  &:hover:not(:disabled) {
+    background-color: $ligray-hover;
+  }
+}
+
 .ligray {
   background-color: $ligray;
   color: $ligray-text;

--- a/src/components/shared/Button/Button.tsx
+++ b/src/components/shared/Button/Button.tsx
@@ -1,7 +1,7 @@
 import styles from './Button.module.scss';
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: 'gray' | 'red' | 'ligray' | 'blue' | 'outline';
+  variant?: 'gray' | 'red' | 'ligray' | 'blue' | 'white' | 'outline';
   size?: 'sm' | 'md' | 'lg';
   shape?: 'square' | 'round';
 };


### PR DESCRIPTION
### 작업 내용
- PWA 설치 안내 배너 UI/동작 구현
- iOS 및 Android/Chrome 환경별 설치 안내 분기 처리
- 배너 닫기 상태 저장으로 재노출 방지
- `Button` 컴포넌트 `white` variant 및 관련 스타일 추가