### PR TITLE
fix: 같은 날짜 중복 기록 시 차트 포인트 겹침 및 툴팁 오표시 문제 수정

### DIFF
--- a/src/components/RecordChart/RecordChart.tsx
+++ b/src/components/RecordChart/RecordChart.tsx
@@ -46,6 +46,7 @@ type CustomTooltipProps = {
 
 type ChartDataPoint = StrengthRecord & {
   fullDate: string;
+  xKey: string;
   displayValue: number;
 };
 
@@ -108,6 +109,9 @@ export default function RecordChart({ userId }: RecordChartProps) {
             month: 'long',
             day: 'numeric',
           }),
+          xKey: r.recorded_at
+            ? `${r.recorded_at}_${r.created_at}`
+            : r.created_at,
           displayValue:
             typeof r[activePart.key] === 'number' ? r[activePart.key] : 0,
         };
@@ -178,9 +182,9 @@ export default function RecordChart({ userId }: RecordChartProps) {
                 className={styles.chartGrid}
               />
               <XAxis
-                dataKey={(r) => r.recorded_at || r.created_at}
+                dataKey='xKey'
                 tickFormatter={(val) => {
-                  const d = new Date(val);
+                  const d = new Date(val.split('_')[0]);
                   return `${d.getMonth() + 1}/${d.getDate()}`;
                 }}
                 tick={{ className: styles.chartTick }}


### PR DESCRIPTION
### 작업 내용
- xKey를 recorded_at + created_at 조합으로 생성해 중복 날짜 포인트 분리
- XAxis dataKey를 xKey로 변경 및 tickFormatter에서 날짜 파싱 처리
- ChartDataPoint 타입에 xKey 필드 추가