### PR TITLE
feat: 회원 탈퇴 기능 구현

### DIFF
--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
@@ -7,10 +7,10 @@ import { Camera } from 'lucide-react';
 
 import styles from './ProfileEdit.module.scss';
 
-import Button from '../../../shared/Button/Button';
+import Button from '@/components/shared/Button/Button';
+import Loading from '@/components/shared/Loading/Loading';
 
 import { useProfileUpdate } from '@/hooks/useProfileUpdate';
-import Loading from '@/components/shared/Loading/Loading';
 
 type ProfileEditProps = {
   user: User;
@@ -36,8 +36,13 @@ export default function ProfileEdit({
   const [tempAvatar, setTempAvatar] = useState<string>(initialAvatar);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const { uploadImage, saveFullProfile, resetProfile, uploading } =
-    useProfileUpdate(user);
+  const {
+    uploadImage,
+    saveFullProfile,
+    resetProfile,
+    deleteAccount,
+    uploading,
+  } = useProfileUpdate(user);
 
   const handleFileChange = async (
     e: ChangeEvent<HTMLInputElement>,
@@ -119,8 +124,22 @@ export default function ProfileEdit({
     }
   };
 
-  const handleDeleteAccount = (): void => {
-    alert('준비 중인 기능이에요.');
+  const handleDeleteAccount = async (): Promise<void> => {
+    if (!confirm('정말 탈퇴하시겠습니까?')) return;
+    if (
+      !confirm(
+        '모든 데이터가 삭제되며 복구할 수 없습니다.\n정말 탈퇴하시겠습니까?',
+      )
+    )
+      return;
+
+    const success = await deleteAccount();
+    if (success) {
+      alert('탈퇴가 완료되었습니다.');
+      window.location.href = '/';
+    } else {
+      alert('탈퇴 처리 중 오류가 발생했습니다. 다시 시도해 주세요.');
+    }
   };
 
   return (

--- a/src/hooks/useProfileUpdate.ts
+++ b/src/hooks/useProfileUpdate.ts
@@ -98,5 +98,36 @@ export function useProfileUpdate(user: User) {
     }
   };
 
-  return { uploadImage, saveFullProfile, resetProfile, uploading };
+  // 회원 탈퇴
+  const deleteAccount = async (): Promise<boolean> => {
+    try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) return false;
+
+      const res = await fetch('/api/account/delete', {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+        },
+      });
+
+      if (!res.ok) throw new Error('Delete failed');
+
+      await supabase.auth.signOut();
+      return true;
+    } catch (error) {
+      console.error('Delete account error:', error);
+      return false;
+    }
+  };
+
+  return {
+    uploadImage,
+    saveFullProfile,
+    resetProfile,
+    deleteAccount,
+    uploading,
+  };
 }


### PR DESCRIPTION
### 작업 내용
- `deleteAccount` 함수 추가
- 세션 토큰을 Authorization 헤더에 담아 `/api/account/delete` API 호출
- 탈퇴 성공 시 자동 로그아웃(`supabase.auth.signOut`) 처리
- `handleDeleteAccount`를 더미 alert에서 실제 로직으로 교체
- 2단계 confirm으로 실수 탈퇴 방지
- 탈퇴 성공 시 홈(`/`)으로 리다이렉트
- 탈퇴 실패 시 오류 메시지 안내