### PR TITLE
feat: ConfirmToast 컴포넌트 구현

### DIFF
--- a/src/components/shared/ConfirmToast/ConfirmToast.module.scss
+++ b/src/components/shared/ConfirmToast/ConfirmToast.module.scss
@@ -1,0 +1,31 @@
+@use '../../../styles' as *;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: $white;
+  border: 1px solid $border-soft;
+  border-radius: $radius-main;
+  padding: 16px;
+  box-shadow: $shadow-md;
+  width: 356px;
+  max-width: 90vw;
+  margin: 0 auto;
+}
+
+.message {
+  @include font-md-title;
+  @include flex-center;
+  line-height: 1.6;
+  word-break: keep-all;
+  white-space: pre-wrap;
+  color: $text-dark;
+  margin: 0;
+  text-align: center;
+}
+
+.actions {
+  @include flex-center;
+  gap: 8px;
+}

--- a/src/components/shared/ConfirmToast/ConfirmToast.tsx
+++ b/src/components/shared/ConfirmToast/ConfirmToast.tsx
@@ -1,0 +1,35 @@
+import { toast } from 'sonner';
+
+import styles from './ConfirmToast.module.scss';
+
+import Button from '../Button/Button';
+
+export function ConfirmToast(message: string, onConfirm: () => void) {
+  toast.custom(
+    (id) => (
+      <div className={styles.container}>
+        <p className={styles.message}>{message}</p>
+        <div className={styles.actions}>
+          <Button
+            variant='ligray'
+            className={styles.cancel}
+            onClick={() => toast.dismiss(id)}
+          >
+            취소
+          </Button>
+          <Button
+            variant='blue'
+            className={styles.confirm}
+            onClick={() => {
+              toast.dismiss(id);
+              onConfirm();
+            }}
+          >
+            확인
+          </Button>
+        </div>
+      </div>
+    ),
+    { duration: Infinity },
+  );
+}


### PR DESCRIPTION
### 작업 내용
- `ConfirmToast` 컴포넌트 및 스타일 추가
- 취소/확인 버튼으로 사용자 인터랙션 처리
- `duration: Infinity` 설정으로 명시적 닫기 전까지 토스트 유지