### PR TITLE
refactor: window.confirm ConfirmToast 컴포넌트로 교체

### DIFF
--- a/src/components/AuthForm/AuthForm.tsx
+++ b/src/components/AuthForm/AuthForm.tsx
@@ -7,6 +7,7 @@ import styles from './AuthForm.module.scss';
 
 import Button from '../shared/Button/Button';
 import Loading from '../shared/Loading/Loading';
+import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
 
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
@@ -42,15 +43,18 @@ export default function AuthForm() {
         <Button
           variant='gray'
           size='sm'
-          onClick={async () => {
-            if (!confirm('로그아웃 하시겠습니까?')) return;
-            try {
-              await signOut();
-              toast.info('로그아웃 되었습니다. 내일도 득근!');
-              window.location.href = '/';
-            } catch (error) {
-              toast.error(`로그아웃 중 오류 발생: ${(error as Error).message}`);
-            }
+          onClick={() => {
+            ConfirmToast('로그아웃 하시겠습니까?', async () => {
+              try {
+                await signOut();
+                toast.info('로그아웃 되었습니다. 내일도 득근!');
+                window.location.href = '/';
+              } catch (error) {
+                toast.error(
+                  `로그아웃 중 오류 발생: ${(error as Error).message}`,
+                );
+              }
+            });
           }}
         >
           로그아웃

--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -14,6 +14,7 @@ import ActionsSection from './components/ActionsSection/ActionsSection';
 
 import Loading from '../shared/Loading/Loading';
 import Empty from '../shared/Empty/Empty';
+import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
 
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
@@ -71,7 +72,7 @@ export default function ProfileCard({
   };
 
   // 공개/비공개
-  const handleTogglePublic = async () => {
+  const handleTogglePublic = () => {
     if (!profile || !canEdit) return;
 
     const nextPublicStatus = !profile.is_public;
@@ -80,25 +81,25 @@ export default function ProfileCard({
       ? '내 기록을 공유하고 함께 운동해볼까요?'
       : '내 기록을 비밀로 유지할까요?';
 
-    if (!confirm(confirmMessage)) return;
-
-    const success = await saveFullProfile(
-      profile.nickname,
-      profile.status_message,
-      profile.avatar_url,
-      nextPublicStatus,
-    );
-
-    if (success) {
-      queryClient.invalidateQueries({ queryKey: ['profile', targetId] });
-      queryClient.invalidateQueries({ queryKey: ['users'] });
-
-      toast.info(
-        nextPublicStatus
-          ? '프로필이 전체 공개로 설정되었습니다.'
-          : '프로필이 비공개로 설정되었습니다.',
+    ConfirmToast(confirmMessage, async () => {
+      const success = await saveFullProfile(
+        profile.nickname,
+        profile.status_message,
+        profile.avatar_url,
+        nextPublicStatus,
       );
-    }
+
+      if (success) {
+        queryClient.invalidateQueries({ queryKey: ['profile', targetId] });
+        queryClient.invalidateQueries({ queryKey: ['users'] });
+
+        toast.info(
+          nextPublicStatus
+            ? '프로필이 전체 공개로 설정되었습니다.'
+            : '프로필이 비공개로 설정되었습니다.',
+        );
+      }
+    });
   };
 
   const cycleStage = () => {

--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
@@ -10,6 +10,7 @@ import styles from './ProfileEdit.module.scss';
 
 import Button from '@/components/shared/Button/Button';
 import Loading from '@/components/shared/Loading/Loading';
+import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
 
 import { useProfileUpdate } from '@/hooks/useProfileUpdate';
 
@@ -54,7 +55,7 @@ export default function ProfileEdit({
     if (publicUrl) setTempAvatar(publicUrl);
   };
 
-  const handleConfirmSave = async (): Promise<void> => {
+  const handleConfirmSave = (): void => {
     const trimmedNickname = tempNickname.trim();
     const trimmedStatus = tempStatus.trim();
 
@@ -75,7 +76,7 @@ export default function ProfileEdit({
       return;
     }
 
-    if (confirm('정말 변경하시겠습니까?')) {
+    ConfirmToast('정말 변경하시겠습니까?', async () => {
       const success = await saveFullProfile(
         trimmedNickname,
         trimmedStatus,
@@ -87,7 +88,7 @@ export default function ProfileEdit({
         onEditingChange(false);
         toast.success('프로필이 변경되었습니다!');
       }
-    }
+    });
   };
 
   const handleCancel = () => {
@@ -97,50 +98,53 @@ export default function ProfileEdit({
       tempAvatar !== initialAvatar;
 
     if (isChanged) {
-      if (confirm('수정 중인 내용은 저장되지 않습니다. 취소하시겠습니까?')) {
+      ConfirmToast(
+        '수정 중인 내용은 저장되지 않습니다. 취소하시겠습니까?',
+        () => onEditingChange(false),
+      );
+    } else {
+      onEditingChange(false);
+    }
+  };
+
+  const handleReset = (): void => {
+    ConfirmToast('프로필을 처음 상태로 초기화할까요?', async () => {
+      const success = await resetProfile();
+      if (success) {
+        const defaultNickname =
+          user.user_metadata?.full_name ||
+          user.user_metadata?.name ||
+          '울끈불끈이';
+        const defaultAvatar =
+          user.user_metadata?.avatar_url || user.user_metadata?.picture || '';
+        const defaultStatus = '울끈불끈!';
+        setTempNickname(defaultNickname);
+        setTempAvatar(defaultAvatar);
+        setTempStatus(defaultStatus);
+        onUpdate(defaultNickname, defaultAvatar, defaultStatus);
         onEditingChange(false);
+        toast.success('프로필이 초기화되었습니다!');
       }
-    } else {
-      onEditingChange(false);
-    }
+    });
   };
 
-  const handleReset = async (): Promise<void> => {
-    if (!confirm('프로필을 처음 상태로 초기화할까요?')) return;
-    const success = await resetProfile();
-    if (success) {
-      const defaultNickname =
-        user.user_metadata?.full_name ||
-        user.user_metadata?.name ||
-        '울끈불끈이';
-      const defaultAvatar =
-        user.user_metadata?.avatar_url || user.user_metadata?.picture || '';
-      const defaultStatus = '울끈불끈!';
-      setTempNickname(defaultNickname);
-      setTempAvatar(defaultAvatar);
-      setTempStatus(defaultStatus);
-      onUpdate(defaultNickname, defaultAvatar, defaultStatus);
-      onEditingChange(false);
-      toast.success('프로필이 초기화되었습니다!');
-    }
-  };
-
-  const handleDeleteAccount = async (): Promise<void> => {
-    if (!confirm('정말 탈퇴하시겠습니까?')) return;
-    if (
-      !confirm(
-        '모든 데이터가 삭제되며 복구할 수 없습니다.\n정말 탈퇴하시겠습니까?',
-      )
-    )
-      return;
-
-    const success = await deleteAccount();
-    if (success) {
-      toast.success('탈퇴가 완료되었습니다.');
-      window.location.href = '/';
-    } else {
-      toast.error('탈퇴 처리 중 오류가 발생했습니다. 다시 시도해 주세요.');
-    }
+  const handleDeleteAccount = (): void => {
+    ConfirmToast('정말 탈퇴하시겠습니까?', () => {
+      ConfirmToast(
+        '모든 데이터가 삭제되며\n 복구할 수 없습니다.\n 정말 탈퇴하시겠습니까?',
+        async () => {
+          const success = await deleteAccount();
+          if (success) {
+            toast.success('탈퇴가 완료되었습니다.');
+            window.location.href = '/';
+          } else {
+            toast.error(
+              '탈퇴 처리 중 오류가 발생했습니다. 다시 시도해 주세요.',
+            );
+          }
+        },
+      );
+    });
   };
 
   return (

--- a/src/components/RecordList/RecordList.tsx
+++ b/src/components/RecordList/RecordList.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 
 import styles from './RecordList.module.scss';
 
+import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
 import Pagination from '../shared/Pagination/Pagination';
 import Loading from '../shared/Loading/Loading';
 import Button from '../shared/Button/Button';
@@ -165,13 +166,17 @@ export default function RecordList({ userId }: RecordListProps) {
                           <Button
                             variant='red'
                             size='sm'
-                            onClick={async () => {
-                              if (!confirm('정말 삭제하시겠습니까?')) return;
-                              try {
-                                await deleteRecord(r.id);
-                              } catch (e) {
-                                toast.error('삭제에 실패했습니다.');
-                              }
+                            onClick={() => {
+                              ConfirmToast(
+                                '정말 삭제하시겠습니까?',
+                                async () => {
+                                  try {
+                                    await deleteRecord(r.id);
+                                  } catch (e) {
+                                    toast.error('삭제에 실패했습니다.');
+                                  }
+                                },
+                              );
                             }}
                           >
                             삭제


### PR DESCRIPTION
### 작업내용
- `window.confirm` → `ConfirmToast` 컴포넌트로 교체
- `AuthForm` - 로그아웃 확인
- `Profile` - 프로필 공개/비공개 전환 확인
- `ProfileEdit` - 프로필 저장, 취소, 초기화, 회원 탈퇴 확인
- `RecordList` - 기록 삭제 확인