### PR TITLE
feat: 운동 기록 리스트 모바일 반응형 레이아웃 및 테이블 셀 개선

### DIFF
--- a/src/components/RecordList/RecordList.module.scss
+++ b/src/components/RecordList/RecordList.module.scss
@@ -10,12 +10,11 @@
   overflow: hidden;
 
   h1 {
-    @include font-md-title;
+    @include font-lg-title;
     color: $text-dark;
     margin-bottom: 20px;
 
     strong {
-      @include font-md-title;
       color: $blue;
     }
   }
@@ -29,7 +28,7 @@
       text-align: center;
 
       th {
-        @include font-th;
+        @include font-md-title;
         background: $white;
         padding: 10px;
         color: $ligray-text;
@@ -42,7 +41,7 @@
       }
 
       td {
-        @include font-td;
+        @include font-body;
         padding: 12px;
         border-bottom: 1px solid $border-soft;
         white-space: nowrap;
@@ -87,7 +86,6 @@
     transition:
       opacity 0.15s ease,
       transform 0.15s ease;
-    z-index: 10;
 
     &::after {
       content: '';
@@ -97,6 +95,95 @@
       transform: translateX(-50%);
       border: 5px solid transparent;
       border-top-color: $dark;
+    }
+  }
+}
+
+// 모바일 카드
+@media (max-width: 768px) {
+  .listContainer {
+    padding: 20px 10px;
+  }
+
+  .listTable {
+    thead {
+      display: none;
+    }
+
+    tbody tr {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      grid-template-areas:
+        'manage manage manage manage'
+        'date   date   date   date'
+        'lift1  lift2  lift3  lift4'
+        'total  total  total  total';
+      background: $white;
+      border: 1px solid $border-soft;
+      border-radius: $radius-main;
+      margin-bottom: 12px;
+      box-shadow: $shadow-md;
+      overflow: hidden;
+    }
+
+    td {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 10px 12px;
+      border-bottom: 1px solid $border-soft;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &::before {
+        content: attr(data-label);
+        @include font-body;
+        color: $ligray-text;
+        margin-bottom: 4px;
+      }
+    }
+
+    td:nth-child(1),
+    td:nth-child(6),
+    td:nth-child(7) {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+
+      &::before {
+        margin-bottom: 0;
+        margin-right: 8px;
+      }
+    }
+
+    td:nth-child(1) {
+      grid-area: date;
+    }
+    td:nth-child(2) {
+      grid-area: lift1;
+      border-right: 1px solid $border-soft;
+    }
+    td:nth-child(3) {
+      grid-area: lift2;
+      border-right: 1px solid $border-soft;
+    }
+    td:nth-child(4) {
+      grid-area: lift3;
+      border-right: 1px solid $border-soft;
+    }
+    td:nth-child(5) {
+      grid-area: lift4;
+    }
+
+    td:nth-child(6) {
+      grid-area: total;
+      border-top: 2px solid $border-light;
+    }
+
+    td:nth-child(7) {
+      grid-area: manage;
     }
   }
 }

--- a/src/components/RecordList/RecordList.tsx
+++ b/src/components/RecordList/RecordList.tsx
@@ -23,27 +23,40 @@ type RecordListProps = {
   userId?: string;
 };
 
-const PAGE_SIZE = 6;
+const PAGE_SIZE = 7;
 
 type RepsTooltipProps = {
   weight: number | null;
   reps: number;
   label: string;
+  className?: string;
 };
 
-function WeightCell({ weight, reps, label }: RepsTooltipProps) {
-  if (weight === null || weight === undefined) return <td>-</td>;
+function WeightCell({ weight, reps, label, className }: RepsTooltipProps) {
+  if (weight === null || weight === undefined)
+    return (
+      <td data-label={label} className={className}>
+        -
+      </td>
+    );
 
   if (weight === 0) {
-    return <td>0kg</td>;
+    return (
+      <td data-label={label} className={className}>
+        0kg
+      </td>
+    );
   }
 
   return (
-    <td className={styles.weightCell}>
+    <td
+      data-label={label}
+      className={`${styles.weightCell} ${className ?? ''}`}
+    >
       <span className={styles.weightWithTooltip}>
         {weight}kg
         <span className={styles.tooltip}>
-          {label} {weight}kg x {reps}회
+          {weight}kg x {reps}회
         </span>
       </span>
     </td>
@@ -150,7 +163,7 @@ export default function RecordList({ userId }: RecordListProps) {
 
                   return (
                     <tr key={r.id}>
-                      <td>
+                      <td data-label='날짜'>
                         {!isReadOnly && editingId === r.id ? (
                           <input
                             type='date'
@@ -187,26 +200,32 @@ export default function RecordList({ userId }: RecordListProps) {
                         weight={r.squat}
                         reps={r.squat_reps ?? 1}
                         label='스쿼트'
+                        className={styles.liftCell}
                       />
                       <WeightCell
                         weight={r.deadlift}
                         reps={r.deadlift_reps ?? 1}
                         label='데드'
+                        className={styles.liftCell}
                       />
                       <WeightCell
                         weight={r.bench_press}
                         reps={r.bench_press_reps ?? 1}
                         label='벤치'
+                        className={styles.liftCell}
                       />
                       <WeightCell
                         weight={r.ohp}
                         reps={r.ohp_reps ?? 1}
                         label='OHP'
+                        className={styles.liftCell}
                       />
-                      <td className={styles.total}>{r.total_weight}kg</td>
+                      <td data-label='합계' className={styles.total}>
+                        {r.total_weight}kg
+                      </td>
 
                       {!isReadOnly && (
-                        <td>
+                        <td data-label='관리'>
                           <Button
                             variant='red'
                             size='sm'


### PR DESCRIPTION
### 작업 내용
- PAGE_SIZE 6 → 7 변경
- `WeightCell`에 `className` prop 추가 및 `liftCell` 클래스 적용
- 각 `td`에 `data-label` 속성 추가 (모바일 레이블 표시 대응)
- `WeightCell` 툴팁에서 운동 종목명 레이블 제거
- 모바일(768px 이하) 카드형 레이아웃 추가
- `thead` 숨김 처리
- `tbody tr`을 grid(4열)로 변환, `grid-area`로 영역 배치
- `td::before`로 `data-label` 활용한 레이블 표시
- `h1` 폰트 `font-md-title` → `font-lg-title` 변경
- `th` 폰트 `font-th` → `font-md-title` 변경
- `td` 폰트 `font-td` → `font-body` 변경
- tooltip `z-index` 제거