### PR TITLE
refactor: 프로필 편집 UI 레이아웃 및 스타일 구조 개선

### DIFF
--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.module.scss
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.module.scss
@@ -1,133 +1,127 @@
 @use '../../../../styles' as *;
 
 .editContainer {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
   width: 100%;
   padding-top: 8px;
 
-  .avatarContainer {
+  .editWrapper {
+    gap: 20px;
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding-bottom: 10px;
 
-    .avatarWrapper {
-      position: relative;
-      width: 80px;
-      height: 80px;
-      border-radius: 50%;
-      overflow: hidden;
-      cursor: pointer;
-      flex-shrink: 0;
-      box-shadow: $shadow-md;
-      border: 1px solid $border-liblue;
-
-      &:hover .avatarOverlay {
-        opacity: 1;
-      }
-
-      .avatar {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-      }
-
-      .defaultAvatar {
-        @include font-xl-title;
-        @include flex-center;
-        line-height: 1;
-        user-select: none;
-        background-color: $white;
-      }
-
-      .avatarOverlay {
-        @include flex-center;
-        @include font-sm;
-        font-weight: 500;
-        position: absolute;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.4);
-        color: $white;
-        opacity: 0;
-        transition: opacity 0.2s;
-      }
-
-      .uploadLoading {
-        @include flex-center;
-        position: absolute;
-        top: 30;
-      }
-    }
-  }
-
-  .fieldList {
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-    width: 100%;
-
-    .field {
+    .avatarContainer {
       display: flex;
       flex-direction: column;
-      gap: 6px;
+      align-items: center;
 
-      label {
-        @include font-sm;
-        color: $text-muted;
-        font-weight: $font-medium;
-        padding-left: 2px;
-      }
-
-      .inputWrapper {
+      .avatarWrapper {
         position: relative;
-        width: 100%;
+        width: 80px;
+        height: 80px;
+        border-radius: 50%;
+        overflow: hidden;
+        cursor: pointer;
+        flex-shrink: 0;
+        box-shadow: $shadow-md;
+        border: 1px solid $border-liblue;
 
-        input {
-          @include font-body;
-          width: 100%;
-          border: 1.5px solid $border-soft;
-          border-radius: $radius-main;
-          padding: 10px 44px 10px 12px;
-          outline: none;
-          background: $off-white;
-          color: $text-dark;
-          transition:
-            border-color 0.2s,
-            background 0.2s;
-
-          &:focus {
-            border-color: $blue;
-            background: $white;
-          }
-
-          &::placeholder {
-            color: $gray;
-            font-weight: $font-light;
-          }
+        &:hover .avatarOverlay {
+          opacity: 1;
         }
 
-        span {
+        .avatar {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+        }
+
+        .defaultAvatar {
+          @include font-xl-title;
+          @include flex-center;
+          line-height: 1;
+          user-select: none;
+          background-color: $white;
+        }
+
+        .avatarOverlay {
+          @include flex-center;
           @include font-sm;
+          font-weight: 500;
           position: absolute;
-          right: 10px;
-          top: 50%;
-          transform: translateY(-50%);
-          color: $gray;
-          pointer-events: none;
+          inset: 0;
+          background: rgba(0, 0, 0, 0.4);
+          color: $white;
+          opacity: 0;
+          transition: opacity 0.2s;
+        }
+
+        .uploadLoading {
+          @include flex-center;
+          position: absolute;
+          top: 30;
         }
       }
     }
-  }
 
-  .editBtns {
-    display: flex;
-    gap: 8px;
-    width: 100%;
+    .fieldList {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      width: 100%;
 
-    button {
-      flex: 1;
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+
+        label {
+          @include font-sm;
+          color: $text-muted;
+          font-weight: $font-medium;
+          padding-left: 2px;
+        }
+
+        .inputWrapper {
+          position: relative;
+          width: 100%;
+
+          input {
+            @include font-body;
+            width: 100%;
+            border: 1.5px solid $border-soft;
+            border-radius: $radius-main;
+            padding: 10px 44px 10px 12px;
+            outline: none;
+            background: $off-white;
+            color: $text-dark;
+            transition:
+              border-color 0.2s,
+              background 0.2s;
+
+            &:focus {
+              border-color: $blue;
+              background: $white;
+            }
+
+            &::placeholder {
+              color: $gray;
+              font-weight: $font-light;
+            }
+          }
+
+          span {
+            @include font-sm;
+            position: absolute;
+            right: 10px;
+            top: 50%;
+            transform: translateY(-50%);
+            color: $gray;
+            pointer-events: none;
+          }
+        }
+      }
     }
   }
 
@@ -137,6 +131,19 @@
     gap: 8px;
     width: 100%;
     padding-top: 10px;
+    padding-bottom: 10px;
     border-top: 1px solid $border-soft;
+  }
+
+  .editBtns {
+    display: flex;
+    gap: 8px;
+    width: 100%;
+    padding-top: 10px;
+    border-top: 1px solid $border-soft;
+
+    button {
+      flex: 1;
+    }
   }
 }

--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
@@ -149,88 +149,92 @@ export default function ProfileEdit({
 
   return (
     <div className={styles.editContainer}>
-      <div className={styles.avatarContainer}>
-        <div
-          className={styles.avatarWrapper}
-          onClick={() => !uploading && fileInputRef.current?.click()}
-        >
-          {tempAvatar ? (
-            <Image
-              src={tempAvatar}
-              alt={`${tempNickname}님의 프로필 편집`}
-              className={styles.avatar}
-              width={85}
-              height={85}
-              unoptimized
-            />
-          ) : (
-            <div className={`${styles.avatar} ${styles.defaultAvatar}`}>💪</div>
-          )}
-          <div className={styles.avatarOverlay}>
-            {uploading ? (
-              <div className={styles.avatarLoading}>
-                <Loading size='sm' message='' />
-              </div>
+      <div className={styles.editWrapper}>
+        <div className={styles.avatarContainer}>
+          <div
+            className={styles.avatarWrapper}
+            onClick={() => !uploading && fileInputRef.current?.click()}
+          >
+            {tempAvatar ? (
+              <Image
+                src={tempAvatar}
+                alt={`${tempNickname}님의 프로필 편집`}
+                className={styles.avatar}
+                width={85}
+                height={85}
+                unoptimized
+              />
             ) : (
-              <Camera size={18} strokeWidth={2} />
+              <div className={`${styles.avatar} ${styles.defaultAvatar}`}>
+                💪
+              </div>
             )}
+            <div className={styles.avatarOverlay}>
+              {uploading ? (
+                <div className={styles.avatarLoading}>
+                  <Loading size='sm' message='' />
+                </div>
+              ) : (
+                <Camera size={18} strokeWidth={2} />
+              )}
+            </div>
           </div>
-        </div>
-        <input
-          type='file'
-          ref={fileInputRef}
-          onChange={handleFileChange}
-          hidden
-          accept='image/*'
-        />
-      </div>
-
-      <div className={styles.fieldList}>
-        <div className={styles.field}>
-          <label>상태 메시지</label>
-          <div className={styles.inputWrapper}>
-            <input
-              type='text'
-              value={tempStatus}
-              onChange={(e) => setTempStatus(e.target.value)}
-              placeholder='상태 메시지를 입력해주세요.'
-              maxLength={20}
-              autoFocus
-            />
-            <span>{tempStatus.length}/20</span>
-          </div>
+          <input
+            type='file'
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            hidden
+            accept='image/*'
+          />
         </div>
 
-        <div className={styles.field}>
-          <label>닉네임</label>
-          <div className={styles.inputWrapper}>
-            <input
-              type='text'
-              value={tempNickname}
-              onChange={(e) => setTempNickname(e.target.value)}
-              placeholder='닉네임을 입력해주세요.'
-              maxLength={10}
-            />
-            <span>{tempNickname.length}/10</span>
+        <div className={styles.fieldList}>
+          <div className={styles.field}>
+            <label>상태 메시지</label>
+            <div className={styles.inputWrapper}>
+              <input
+                type='text'
+                value={tempStatus}
+                onChange={(e) => setTempStatus(e.target.value)}
+                placeholder='상태 메시지를 입력해주세요.'
+                maxLength={20}
+                autoFocus
+              />
+              <span>{tempStatus.length}/20</span>
+            </div>
+          </div>
+
+          <div className={styles.field}>
+            <label>닉네임</label>
+            <div className={styles.inputWrapper}>
+              <input
+                type='text'
+                value={tempNickname}
+                onChange={(e) => setTempNickname(e.target.value)}
+                placeholder='닉네임을 입력해주세요.'
+                maxLength={10}
+              />
+              <span>{tempNickname.length}/10</span>
+            </div>
           </div>
         </div>
-      </div>
-
-      <div className={styles.editBtns}>
-        <Button variant='blue' size='sm' onClick={handleConfirmSave}>
-          저장
-        </Button>
-        <Button variant='gray' size='sm' onClick={handleCancel}>
-          취소
-        </Button>
       </div>
 
       <div className={styles.dangerBtns}>
-        <Button variant='ligray' size='sm' onClick={handleReset}>
+        <Button variant='gray' size='sm' onClick={handleReset}>
           프로필 초기화
         </Button>
         <Button variant='red' size='sm' onClick={handleDeleteAccount}>
           회원 탈퇴
+        </Button>
+      </div>
+
+      <div className={styles.editBtns}>
+        <Button variant='ligray' size='md' onClick={handleCancel}>
+          취소
+        </Button>
+        <Button variant='blue' size='md' onClick={handleConfirmSave}>
+          저장
         </Button>
       </div>
     </div>


### PR DESCRIPTION
### 작업 내용
- `editWrapper` 추가로 아바타·필드 영역 그룹화
- 버튼 영역 순서 재배치: 저장/취소 → dangerBtns → editBtns(취소/저장)
- 취소/저장 버튼 크기 `sm` → `md` 변경
- 프로필 초기화 버튼 variant `ligray` → `gray` 변경
- `dangerBtns`, `editBtns` 각각 `border-top` 구분선 추가로 섹션 시각적 분리