### PR TITLE
feat: 운동 기록 폼 입력 유효성 검사 추가 및 UI 개선

### DIFF
--- a/src/components/RecordForm/RecordForm.module.scss
+++ b/src/components/RecordForm/RecordForm.module.scss
@@ -17,7 +17,7 @@
   .title {
     text-align: center;
     margin-bottom: 2.5rem;
-    @include font-lg-title;
+    @include font-xl-title;
   }
 
   form {
@@ -40,7 +40,7 @@
           flex: 2.5;
           min-width: 0;
           width: 100%;
-          @include font-sm;
+          @include font-body;
         }
 
         .repsWrapper {
@@ -54,7 +54,7 @@
             width: 100%;
             min-width: 0;
             text-align: center;
-            @include font-sm;
+            @include font-body;
             border-width: 2px;
 
             &.committed {
@@ -117,7 +117,6 @@
     }
 
     .submitBtn {
-      @include font-body;
       padding: 1rem;
       width: 100%;
     }

--- a/src/components/RecordForm/RecordForm.tsx
+++ b/src/components/RecordForm/RecordForm.tsx
@@ -3,15 +3,15 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import styles from './RecordForm.module.scss';
-
-import Button from '../shared/Button/Button';
+import Button from '@/components/shared/Button/Button';
 
 import { useRecordForm } from '@/hooks/useRecordForm';
 
 import { blockInvalidNumberChars, stopWheelChange } from '@/utils/inputUtils';
 
 import { RecordFormState } from '@/types/record';
+
+import styles from './RecordForm.module.scss';
 
 const FIELDS: {
   name: keyof Pick<
@@ -77,7 +77,7 @@ export default function RecordForm() {
       const field = FIELDS.find((f) => f.name === fieldName);
       toast.success(`${field?.ko || fieldName} 기록 완료!`);
     },
-    onError: (message) => toast.error(`저장 실패: ${message}`),
+    onError: (message) => toast.error(`${message}`),
   });
 
   const isAllRequiredCommitted = FIELDS.filter((f) => f.required).every(
@@ -100,6 +100,7 @@ export default function RecordForm() {
                   type='number'
                   name={name}
                   inputMode='numeric'
+                  max={9999}
                   onKeyDown={blockInvalidNumberChars}
                   onWheel={stopWheelChange}
                   value={record[name]}
@@ -117,7 +118,7 @@ export default function RecordForm() {
                     name={repsKey}
                     inputMode='numeric'
                     min={record[name] === '0' || record[name] === '' ? 0 : 1}
-                    max={30}
+                    max={99}
                     onKeyDown={blockInvalidNumberChars}
                     onWheel={stopWheelChange}
                     value={record[repsKey]}
@@ -145,7 +146,7 @@ export default function RecordForm() {
                 <Button
                   type='button'
                   variant='blue'
-                  size='sm'
+                  size='lg'
                   className={styles.commitBtn}
                   onClick={() => handleCommit(name)}
                   disabled={!user || record[name] === ''}
@@ -175,7 +176,7 @@ export default function RecordForm() {
 
         <Button
           variant='blue'
-          size='md'
+          size='lg'
           type='submit'
           className={styles.submitBtn}
           disabled={!user || !isAllRequiredCommitted}

--- a/src/hooks/useRecordForm.ts
+++ b/src/hooks/useRecordForm.ts
@@ -168,6 +168,16 @@ export function useRecordForm({
     const repsKey = `${fieldName}_reps` as keyof RecordFormState;
     const repsValue = Number(record[repsKey]) || 1;
 
+    if (value < 0 || value > 9999) {
+      onError?.('중량은 9999kg까지 기록할 수 있습니다.');
+      return;
+    }
+
+    if (repsValue < 0 || repsValue > 99) {
+      onError?.('횟수는 99회까지 기록할 수 있습니다.');
+      return;
+    }
+
     try {
       if (draftIdRef.current) {
         const { error } = await supabase

--- a/src/styles/mixins/_forms.scss
+++ b/src/styles/mixins/_forms.scss
@@ -7,12 +7,12 @@
   gap: 0.5rem;
 
   label {
-    @include font-body;
+    @include font-md-title;
     color: $dark;
   }
 
   input {
-    @include font-sm;
+    @include font-body;
 
     /* Chrome, Safari, Edge, Opera에서 화살표 제거 */
     &::-webkit-outer-spin-button,


### PR DESCRIPTION
### 작업 내용
- `handleCommit`에 중량(max 9999kg), 횟수(max 99회) 유효성 검사 추가
- 유효성 검사 실패 시 에러 토스트 노출
- 무게 입력 `max={9999}`, 횟수 입력 `max={99}` 제한 추가
- 커밋/제출 버튼 사이즈 `sm`/`md` → `lg` 통일
- 에러 토스트 메시지에서 '저장 실패:' 접두사 제거
- 폼 전반의 폰트 믹스인 상향 조정 및 정리