### PR TITLE
refactor: 운동 기록 차트 구조 개선 및 경로 재구성

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -4,17 +4,17 @@ import { useParams, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
 
-import styles from './MemberDetail.module.scss';
-
-import RecordChart from '@/components/RecordChart/RecordChart';
-import RecordList from '@/components/RecordList/RecordList';
-import ProfileCard from '@/components/Profile';
-
 import NavBar from '@/components/shared/NavBar/NavBar';
 import Empty from '@/components/shared/Empty/Empty';
 
+import Charts from '@/components/Charts';
+import ProfileCard from '@/components/Profile';
+import RecordList from '@/components/RecordList/RecordList';
+
 import { useProfile } from '@/hooks/useProfile';
 import { useAuth } from '@/hooks/useAuth';
+
+import styles from './MemberDetail.module.scss';
 
 export default function MemberDetailPage() {
   const params = useParams();
@@ -57,7 +57,7 @@ export default function MemberDetailPage() {
 
       <div className={styles.contents}>
         <ProfileCard userId={userId} readOnly={true} />
-        <RecordChart userId={userId} />
+        <Charts userId={userId} />
         <RecordList userId={userId} />
       </div>
     </div>

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -13,7 +13,7 @@
   width: 100%;
   margin-bottom: 20px;
 
-  @media (min-width: 1024px) {
+  @media (min-width: 1300px) {
     grid-template-columns: repeat(2, 1fr);
     align-items: stretch;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import styles from './page.module.scss';
-
-import RecordForm from '@/components/RecordForm/RecordForm';
-import RecordList from '@/components/RecordList/RecordList';
-import RecordChart from '@/components/RecordChart/RecordChart';
-import ProfileCard from '@/components/Profile';
-
 import Empty from '@/components/shared/Empty/Empty';
 import NavBar from '@/components/shared/NavBar/NavBar';
 
+import RecordForm from '@/components/RecordForm/RecordForm';
+import RecordList from '@/components/RecordList/RecordList';
+import Charts from '@/components/Charts';
+import ProfileCard from '@/components/Profile';
+
 import { useAuth } from '@/hooks/useAuth';
+
+import styles from './page.module.scss';
 
 export default function Home() {
   const { user, loading } = useAuth();
@@ -27,7 +27,7 @@ export default function Home() {
         {user ? (
           <>
             <ProfileCard />
-            <RecordChart />
+            <Charts />
             <RecordList />
           </>
         ) : (

--- a/src/components/Charts/Charts.module.scss
+++ b/src/components/Charts/Charts.module.scss
@@ -1,0 +1,5 @@
+@use '../../styles' as *;
+
+.chartsWrapper {
+  width: 100%;
+}

--- a/src/components/Charts/Charts.tsx
+++ b/src/components/Charts/Charts.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import RecordChart from './components/RecordChart/RecordChart';
+
+import styles from './Charts.module.scss';
+
+type ChartsProps = {
+  userId?: string;
+};
+
+export default function Charts({ userId }: ChartsProps) {
+  return (
+    <div className={styles.chartsWrapper}>
+      <RecordChart userId={userId} />
+    </div>
+  );
+}

--- a/src/components/Charts/components/RecordChart/RecordChart.module.scss
+++ b/src/components/Charts/components/RecordChart/RecordChart.module.scss
@@ -1,4 +1,4 @@
-@use '../../styles' as *;
+@use '../../../../styles' as *;
 
 .chartContainer {
   background: $white;
@@ -13,10 +13,17 @@
     padding: 20px 10px;
   }
 
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+  }
+
   h1 {
     @include font-lg-title;
     color: $text-dark;
-    margin-bottom: 20px;
+    margin-bottom: 0;
 
     strong {
       color: $blue;

--- a/src/components/Charts/components/RecordChart/RecordChart.tsx
+++ b/src/components/Charts/components/RecordChart/RecordChart.tsx
@@ -18,20 +18,21 @@ import {
 } from 'recharts/types/component/DefaultTooltipContent';
 import { InfoIcon, ChevronLeft, ChevronRight } from 'lucide-react';
 
-import styles from './RecordChart.module.scss';
-
-import { StrengthRecord } from '@/types/record';
-
-import Button from '../shared/Button/Button';
-import Empty from '../shared/Empty/Empty';
-import Loading from '../shared/Loading/Loading';
+import Button from '@/components/shared/Button/Button';
+import Loading from '@/components/shared/Loading/Loading';
+import Empty from '@/components/shared/Empty/Empty';
 
 import { useRecords } from '@/hooks/useRecords';
 import { useProfile } from '@/hooks/useProfile';
 import { useAuth } from '@/hooks/useAuth';
 
+import { StrengthRecord } from '@/types/record';
+
+import styles from './RecordChart.module.scss';
+
 type RecordChartProps = {
   userId?: string;
+  tabButtons?: React.ReactNode;
 };
 
 type ChartPart = {
@@ -108,7 +109,7 @@ const calc1RM = (weight: number, reps: number): number => {
   return Math.round(weight * (1 + reps / 30));
 };
 
-export default function RecordChart({ userId }: RecordChartProps) {
+export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
   const { user } = useAuth();
   const targetId = userId || user?.id;
 
@@ -131,7 +132,6 @@ export default function RecordChart({ userId }: RecordChartProps) {
   }, []);
 
   const visibleCount = isMobile ? MOBILE_VISIBLE_COUNT : VISIBLE_COUNT;
-
   const isPageLoading = recordsLoading || (isReadOnly && profileLoading);
 
   const chartData = useMemo(() => {
@@ -254,14 +254,17 @@ export default function RecordChart({ userId }: RecordChartProps) {
 
   return (
     <div className={styles.chartContainer}>
-      <h1>
-        {displayName && (
-          <>
-            <strong>{displayName}</strong> 님의{' '}
-          </>
-        )}
-        성장 곡선
-      </h1>
+      <div className={styles.header}>
+        <h1>
+          {displayName && (
+            <>
+              <strong>{displayName}</strong> 님의{' '}
+            </>
+          )}
+          성장 곡선
+        </h1>
+        {tabButtons}
+      </div>
 
       {!isPageLoading && records.length >= 2 && (
         <>
@@ -378,7 +381,6 @@ export default function RecordChart({ userId }: RecordChartProps) {
                   unit='kg'
                   width={45}
                 />
-
                 <Tooltip
                   content={
                     <CustomTooltip activePart={activePart} show1RM={show1RM} />
@@ -475,12 +477,10 @@ export default function RecordChart({ userId }: RecordChartProps) {
                     >
                       <ChevronLeft size={20} />
                     </button>
-
                     <span className={styles.brushNavText}>
                       {brushRange.startIndex + 1} - {brushRange.endIndex + 1} /{' '}
                       {chartData.length}개
                     </span>
-
                     <button
                       type='button'
                       aria-label='다음 기록 보기'
@@ -540,12 +540,10 @@ export default function RecordChart({ userId }: RecordChartProps) {
                         <ChevronRight size={20} />
                       </button>
                     </div>
-
                     <span className={styles.brushNavText}>
                       {brushRange.startIndex + 1} - {brushRange.endIndex + 1} /{' '}
                       {chartData.length}개
                     </span>
-
                     <div className={styles.brushNavGroup}>
                       <button
                         type='button'

--- a/src/components/Charts/index.ts
+++ b/src/components/Charts/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Charts';


### PR DESCRIPTION
### 작업 내용
- `RecordChart` 컴포넌트 경로 이동
- `Charts` 래퍼 컴포넌트 신규 추가
- `RecordChart`를 감싸는 `Charts` 컴포넌트 생성
- `userId` props 전달 구조 유지
- `Home` 페이지에서 `RecordChart` 직접 import → `Charts` 컴포넌트로 교체
- `.dashboardGrid` 브레이크포인트 조정 (`1024px` → `1300px`)