### PR TITLE
feat: 종목 밸런스 레이더 차트 컴포넌트 구현

### DIFF
--- a/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.module.scss
+++ b/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.module.scss
@@ -1,0 +1,267 @@
+@use '../../../../styles' as *;
+
+.container {
+  background: $white;
+  box-shadow: $shadow-md;
+  border: 1px solid $border-soft;
+  border-radius: $radius-main;
+  padding: 20px;
+  width: 100%;
+  overflow: hidden;
+
+  @media (max-width: 768px) {
+    padding: 20px 10px;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 4px;
+  }
+
+  h1 {
+    @include font-lg-title;
+    color: $text-dark;
+    margin-bottom: 0;
+
+    strong {
+      color: $blue;
+    }
+  }
+
+  .subtitleRow {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 16px;
+
+    .subtitle {
+      @include font-body;
+      color: $text-muted;
+      margin-bottom: 0;
+    }
+
+    .infoWrapper {
+      position: relative;
+      display: flex;
+      align-items: center;
+
+      &:hover .infoTooltip {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translateY(0);
+      }
+
+      .infoIcon {
+        color: $blue;
+        cursor: default;
+      }
+
+      .infoTooltip {
+        @include font-sm;
+        position: absolute;
+        left: 20px;
+        top: 50%;
+        transform: translateY(4px);
+        opacity: 0;
+        pointer-events: none;
+        transition: $transition-base;
+        background: $white;
+        border: 1px solid $border-soft;
+        border-radius: $radius-main;
+        box-shadow: $shadow-md;
+        padding: 12px 14px;
+        width: 230px;
+        z-index: 1;
+
+        @media (max-width: 768px) {
+          left: auto;
+          right: 0;
+          top: 150%;
+        }
+
+        .infoTitle {
+          color: $text-dark;
+          font-weight: 600;
+          margin: 0 0 8px 0;
+        }
+
+        .infoList {
+          list-style: none;
+          padding: 0;
+          margin: 0 0 8px 0;
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+
+          li {
+            display: flex;
+            justify-content: space-between;
+            color: $text-muted;
+
+            strong {
+              color: $blue;
+              font-weight: 600;
+            }
+          }
+        }
+
+        .infoDesc {
+          color: $text-muted;
+          margin: 0;
+          line-height: 1.5;
+          border-top: 1px solid $border-soft;
+          padding-top: 8px;
+        }
+      }
+    }
+  }
+
+  .contentWrapper {
+    width: 100%;
+    :global(.recharts-wrapper),
+    :global(.recharts-wrapper *),
+    :global(.recharts-surface),
+    :global(.recharts-surface *) {
+      outline: none;
+    }
+
+    .scoreList {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      margin-top: 8px;
+      padding: 0 8px;
+
+      .scoreItem {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+
+        .scoreLabel {
+          @include font-sm;
+          font-weight: 600;
+          width: 60px;
+          flex-shrink: 0;
+          text-align: center;
+        }
+
+        .barWrapper {
+          flex: 1;
+          height: 8px;
+          background: $border-soft;
+          border-radius: 50px;
+          position: relative;
+          overflow: visible;
+
+          .bar {
+            height: 100%;
+            border-radius: 50px;
+            transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+          }
+
+          .baseline {
+            position: absolute;
+            top: -4px;
+            left: calc(100% / 1.5);
+            width: 1.5px;
+            height: 16px;
+            background: $text-muted;
+            opacity: 0.4;
+            border-radius: 1px;
+          }
+        }
+
+        .scoreValue {
+          @include font-sm;
+          font-weight: 600;
+          width: 52px;
+          flex-shrink: 0;
+          text-align: center;
+        }
+      }
+    }
+  }
+
+  .summary {
+    display: flex;
+    gap: 12px;
+    margin-top: 20px;
+
+    @media (max-width: 768px) {
+      flex-direction: column;
+    }
+
+    .summaryItem {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      border-radius: $radius-main;
+      padding: 12px 14px;
+
+      &.strong {
+        background: rgba(#22c55e, 0.07);
+        border: 1px solid rgba(#22c55e, 0.2);
+      }
+
+      &.weak {
+        background: rgba(#f97316, 0.07);
+        border: 1px solid rgba(#f97316, 0.2);
+      }
+
+      .summaryIcon {
+        font-size: 22px;
+        line-height: 1;
+      }
+
+      .summaryLabel {
+        @include font-sm;
+        color: $text-muted;
+        margin: 0 0 2px 0;
+      }
+
+      .summaryValue {
+        @include font-body;
+        font-weight: 700;
+        color: $text-dark;
+        margin: 0;
+
+        span {
+          font-weight: 400;
+          color: $text-muted;
+        }
+      }
+    }
+  }
+}
+
+.tooltip {
+  background: $white;
+  border: 1px solid $border-soft;
+  border-radius: $radius-main;
+  box-shadow: $shadow-md;
+  padding: 12px 14px;
+  min-width: 160px;
+
+  .tooltipTitle {
+    @include font-body;
+    font-weight: 600;
+    color: $text-dark;
+    margin: 0 0 8px 0;
+  }
+
+  .tooltipRow {
+    @include font-sm;
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    margin: 4px 0 0 0;
+    color: $text-muted;
+
+    strong {
+      font-weight: 600;
+    }
+  }
+}

--- a/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.tsx
+++ b/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import { InfoIcon } from 'lucide-react';
+
+import Loading from '@/components/shared/Loading/Loading';
+import Empty from '@/components/shared/Empty/Empty';
+
+import { useRecords } from '@/hooks/useRecords';
+import { useAuth } from '@/hooks/useAuth';
+import { useProfile } from '@/hooks/useProfile';
+
+import { StrengthRecord } from '@/types/record';
+
+import styles from './StrengthRadarChart.module.scss';
+
+type StrengthRadarChartProps = {
+  userId?: string;
+  tabButtons?: React.ReactNode;
+};
+
+const STANDARD_RATIOS: Record<string, number> = {
+  스쿼트: 1.0,
+  데드: 1.2,
+  벤치: 0.75,
+  OHP: 0.5,
+};
+
+const COLORS: Record<string, string> = {
+  스쿼트: '#EF4444',
+  데드: '#F97316',
+  벤치: '#22C55E',
+  OHP: '#A855F7',
+};
+
+const calc1RM = (weight: number, reps: number): number => {
+  if (reps <= 1) return weight;
+  return Math.round(weight * (1 + reps / 30));
+};
+
+const getBest1RM = (
+  records: StrengthRecord[],
+  weightKey: keyof StrengthRecord,
+  repsKey: keyof StrengthRecord,
+): number => {
+  return records.reduce((best, record) => {
+    const weight = Number(record[weightKey] ?? 0);
+    const reps = Number(record[repsKey] ?? 1);
+    const oneRm = weight > 0 ? calc1RM(weight, reps) : 0;
+
+    return oneRm > best ? oneRm : best;
+  }, 0);
+};
+
+const CustomTooltip = ({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: {
+    payload: {
+      subject: string;
+      score: number;
+      my1RM: number;
+      standard: number;
+    };
+  }[];
+}) => {
+  if (active && payload && payload.length) {
+    const d = payload[0].payload;
+
+    return (
+      <div className={styles.tooltip}>
+        <p className={styles.tooltipTitle}>{d.subject}</p>
+        <p className={styles.tooltipRow}>
+          <span>기준 대비</span>
+          <strong style={{ color: d.score >= 100 ? '#007bff' : '#EF4444' }}>
+            {d.score.toFixed(1)}%
+          </strong>
+        </p>
+        <p className={styles.tooltipRow}>
+          <span>최고 추정 1RM</span>
+          <strong>{d.my1RM}kg</strong>
+        </p>
+        <p className={styles.tooltipRow}>
+          <span>기준값</span>
+          <strong>{d.standard}kg</strong>
+        </p>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default function StrengthRadarChart({
+  userId,
+  tabButtons,
+}: StrengthRadarChartProps) {
+  const { user } = useAuth();
+  const targetId = userId || user?.id;
+
+  const { data: records = [], isLoading: recordsLoading } =
+    useRecords(targetId);
+  const { data: profile, isLoading: profileLoading } = useProfile(targetId);
+
+  const isReadOnly = !!userId;
+  const displayName = profile?.nickname || '';
+  const isPageLoading = recordsLoading || (isReadOnly && profileLoading);
+
+  const bestRecords = useMemo(() => {
+    if (!records.length) return null;
+
+    return {
+      squat1rm: getBest1RM(records, 'squat', 'squat_reps'),
+      deadlift1rm: getBest1RM(records, 'deadlift', 'deadlift_reps'),
+      bench1rm: getBest1RM(records, 'bench_press', 'bench_press_reps'),
+      ohp1rm: getBest1RM(records, 'ohp', 'ohp_reps'),
+    };
+  }, [records]);
+
+  const chartData = useMemo(() => {
+    if (!bestRecords) return [];
+
+    const { squat1rm, deadlift1rm, bench1rm, ohp1rm } = bestRecords;
+    const squatBase = squat1rm;
+
+    const items = [
+      { subject: '스쿼트', my1RM: squat1rm },
+      { subject: '데드', my1RM: deadlift1rm },
+      { subject: '벤치', my1RM: bench1rm },
+      { subject: 'OHP', my1RM: ohp1rm },
+    ];
+
+    return items.map((item) => {
+      const standardVal = Math.round(squatBase * STANDARD_RATIOS[item.subject]);
+      const score = standardVal > 0 ? (item.my1RM / standardVal) * 100 : 0;
+
+      return {
+        subject: item.subject,
+        score: Math.min(Math.round(score * 10) / 10, 200),
+        my1RM: item.my1RM,
+        standard: standardVal,
+        fullMark: 150,
+      };
+    });
+  }, [bestRecords]);
+
+  const hasEnoughData =
+    !!bestRecords &&
+    bestRecords.squat1rm > 0 &&
+    bestRecords.deadlift1rm > 0 &&
+    bestRecords.bench1rm > 0;
+
+  const strongest = chartData.length
+    ? chartData.reduce((a, b) => (a.score > b.score ? a : b))
+    : null;
+
+  const weakest = chartData.length
+    ? chartData.reduce((a, b) => (a.score < b.score ? a : b))
+    : null;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h1>
+          {displayName && (
+            <>
+              <strong>{displayName}</strong> 님의{' '}
+            </>
+          )}
+          종목 밸런스
+        </h1>
+
+        {tabButtons}
+      </div>
+
+      <div className={styles.subtitleRow}>
+        <p className={styles.subtitle}>
+          스쿼트 최고 추정 1RM 기준 파워리프팅 권장 비율 대비 수치
+        </p>
+
+        <div className={styles.infoWrapper}>
+          <InfoIcon size={15} className={styles.infoIcon} />
+          <div className={styles.infoTooltip}>
+            <p className={styles.infoTitle}>지표 계산 방식</p>
+            <ul className={styles.infoList}>
+              <li>
+                <span>스쿼트</span>
+                <strong>기준 (1.0)</strong>
+              </li>
+              <li>
+                <span>데드리프트</span>
+                <strong>x 1.2</strong>
+              </li>
+              <li>
+                <span>벤치프레스</span>
+                <strong>x 0.75</strong>
+              </li>
+              <li>
+                <span>OHP</span>
+                <strong>x 0.5</strong>
+              </li>
+            </ul>
+            <p className={styles.infoDesc}>
+              전체 기록 중 종목별 최고 추정 1RM을 기준으로 비교해요. 공식 기준은
+              아니며 밸런스 참고용 지표입니다.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.contentWrapper}>
+        {isPageLoading ? (
+          <Loading message='밸런스를 분석하고 있어요' />
+        ) : !hasEnoughData ? (
+          <Empty
+            message='밸런스 분석을 위한 데이터가 부족합니다.'
+            subMessage='스쿼트, 데드리프트, 벤치프레스 기록이 필요해요.'
+          />
+        ) : (
+          <>
+            <ResponsiveContainer width='100%' height={280}>
+              <RadarChart
+                accessibilityLayer={false}
+                data={chartData}
+                margin={{ top: 10, right: 30, bottom: 10, left: 30 }}
+              >
+                <PolarGrid stroke='var(--border-soft, #e5e7eb)' />
+                <PolarAngleAxis
+                  dataKey='subject'
+                  tick={({ x, y, payload }) => {
+                    const color =
+                      COLORS[payload.value as keyof typeof COLORS] ?? '#6b7280';
+
+                    return (
+                      <text
+                        x={x}
+                        y={y}
+                        textAnchor='middle'
+                        dominantBaseline='central'
+                        fill={color}
+                        fontSize={13}
+                        fontWeight={600}
+                      >
+                        {payload.value}
+                      </text>
+                    );
+                  }}
+                />
+
+                <Tooltip content={<CustomTooltip />} cursor={false} />
+
+                <Radar
+                  name='기준'
+                  dataKey={() => 100}
+                  stroke='#d1d5db'
+                  fill='#f3f4f6'
+                  fillOpacity={0.4}
+                  strokeDasharray='4 4'
+                  strokeWidth={1.5}
+                  dot={false}
+                />
+
+                <Radar
+                  name='수치'
+                  dataKey='score'
+                  stroke='#007bff'
+                  fill='#007bff'
+                  fillOpacity={0.2}
+                  strokeWidth={2.5}
+                  dot={{ r: 4, fill: '#007bff', strokeWidth: 0 }}
+                />
+              </RadarChart>
+            </ResponsiveContainer>
+
+            <div className={styles.scoreList}>
+              {chartData.map((item) => {
+                const isOver = item.score >= 100;
+                const barWidth = Math.min(item.score, 150);
+
+                return (
+                  <div key={item.subject} className={styles.scoreItem}>
+                    <span
+                      className={styles.scoreLabel}
+                      style={{
+                        color: COLORS[item.subject as keyof typeof COLORS],
+                      }}
+                    >
+                      {item.subject}
+                    </span>
+
+                    <div className={styles.barWrapper}>
+                      <div
+                        className={styles.bar}
+                        style={{
+                          width: `${(barWidth / 150) * 100}%`,
+                          backgroundColor: isOver ? '#007bff' : '#93c5fd',
+                        }}
+                      />
+                      <div className={styles.baseline} />
+                    </div>
+
+                    <span
+                      className={styles.scoreValue}
+                      style={{ color: isOver ? '#007bff' : '#6b7280' }}
+                    >
+                      {item.score.toFixed(1)}%
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+
+            {strongest && weakest && strongest.subject !== weakest.subject && (
+              <div className={styles.summary}>
+                <div className={`${styles.summaryItem} ${styles.strong}`}>
+                  <span className={styles.summaryIcon}>💪</span>
+                  <div>
+                    <p className={styles.summaryLabel}>강점</p>
+                    <p className={styles.summaryValue}>
+                      {strongest.subject}{' '}
+                      <span>({strongest.score.toFixed(1)}%)</span>
+                    </p>
+                  </div>
+                </div>
+
+                <div className={`${styles.summaryItem} ${styles.weak}`}>
+                  <span className={styles.summaryIcon}>🎯</span>
+                  <div>
+                    <p className={styles.summaryLabel}>보완 필요</p>
+                    <p className={styles.summaryValue}>
+                      {weakest.subject}{' '}
+                      <span>({weakest.score.toFixed(1)}%)</span>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### 작업 내용
- 전체 기록 중 종목별 최고 추정 1RM 계산 (Epley 공식 기반)
- 스쿼트 1RM 기준 권장 비율(데드 `1.2` / 벤치 `0.75` / OHP `0.5`) 대비 점수화
- `Recharts` `RadarChart`를 활용한 밸런스 시각화
- 바 스코어리스트로 종목별 수치 보조 표시
- 강점 / 보완 필요 종목 요약 카드
- 커스텀 툴팁 (기준 대비 %, 최고 1RM, 기준값 표시)
- 정보 아이콘 `hover` 시 계산 방식 안내 툴팁
- 타인 프로필 조회 시 읽기 전용 모드 지원
- 데이터 부족 시 `Empty` 상태 처리
- 모바일 반응형 대응