### PR TITLE
feat: 차트 탭 전환 기능 추가

### DIFF
--- a/src/components/Charts/Charts.module.scss
+++ b/src/components/Charts/Charts.module.scss
@@ -3,3 +3,35 @@
 .chartsWrapper {
   width: 100%;
 }
+
+.tabGroup {
+  display: flex;
+  gap: 6px;
+}
+
+.tabBtn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px;
+  border-radius: $radius-main;
+  border: 1px solid $border-soft;
+  background: $white;
+  color: $text-muted;
+  cursor: pointer;
+  transition: $transition-base;
+  @include font-sm;
+  font-weight: 500;
+  white-space: nowrap;
+
+  &:hover {
+    border-color: $blue;
+    color: $blue;
+  }
+
+  &.active {
+    background: $blue;
+    border-color: $blue;
+    color: $white;
+  }
+}

--- a/src/components/Charts/Charts.tsx
+++ b/src/components/Charts/Charts.tsx
@@ -1,6 +1,10 @@
 'use client';
 
+import { useState } from 'react';
+import { LineChart, Radar } from 'lucide-react';
+
 import RecordChart from './components/RecordChart/RecordChart';
+import StrengthRadarChart from './components/StrengthRadarChart/StrengthRadarChart';
 
 import styles from './Charts.module.scss';
 
@@ -8,10 +12,38 @@ type ChartsProps = {
   userId?: string;
 };
 
+type ChartView = 'record' | 'radar';
+
+const TABS: { key: ChartView; label: string; icon: React.ReactNode }[] = [
+  { key: 'record', label: '성장 곡선', icon: <LineChart size={20} /> },
+  { key: 'radar', label: '밸런스 분석', icon: <Radar size={20} /> },
+];
+
 export default function Charts({ userId }: ChartsProps) {
+  const [activeView, setActiveView] = useState<ChartView>('record');
+
+  const tabButtons = (
+    <div className={styles.tabGroup}>
+      {TABS.map((tab) => (
+        <button
+          key={tab.key}
+          type='button'
+          className={`${styles.tabBtn} ${activeView === tab.key ? styles.active : ''}`}
+          onClick={() => setActiveView(tab.key)}
+        >
+          {tab.icon}
+        </button>
+      ))}
+    </div>
+  );
+
   return (
     <div className={styles.chartsWrapper}>
-      <RecordChart userId={userId} />
+      {activeView === 'record' ? (
+        <RecordChart userId={userId} tabButtons={tabButtons} />
+      ) : (
+        <StrengthRadarChart userId={userId} tabButtons={tabButtons} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### 작업 내용
- `LineChart` / `Radar` 아이콘 기반 탭 버튼 UI 구현
- `activeView` 상태에 따라 `RecordChart` / `StrengthRadarChart` 조건부 렌더링
- `tabButtons`를 각 차트 컴포넌트에 props로 전달