### PR TITLE
fix: 운동 기록 차트 브러쉬 동작 오류 수정 및 모바일 UX 개선

### DIFF
--- a/src/components/Charts/components/RecordChart/RecordChart.module.scss
+++ b/src/components/Charts/components/RecordChart/RecordChart.module.scss
@@ -237,6 +237,9 @@
       :global(.recharts-brush-traveller) {
         display: none;
       }
+      :global(.recharts-brush-slide) {
+        pointer-events: none;
+      }
     }
   }
 }

--- a/src/components/Charts/components/RecordChart/RecordChart.tsx
+++ b/src/components/Charts/components/RecordChart/RecordChart.tsx
@@ -186,6 +186,7 @@ export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
   >(savedBrushRange);
 
   const prevVisibleCountRef = useRef(visibleCount);
+  const prevActivePartRef = useRef(activePart.key);
 
   // 브러쉬 리셋
   useEffect(() => {
@@ -198,9 +199,12 @@ export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
     if (chartData.length < 2) return;
 
     const visibleCountChanged = prevVisibleCountRef.current !== visibleCount;
-    prevVisibleCountRef.current = visibleCount;
+    const activePartChanged = prevActivePartRef.current !== activePart.key;
 
-    if (savedBrushRange && !visibleCountChanged) {
+    prevVisibleCountRef.current = visibleCount;
+    prevActivePartRef.current = activePart.key;
+
+    if (savedBrushRange && !visibleCountChanged && !activePartChanged) {
       const startIndex = Math.round(
         savedBrushRange.startRatio * (chartData.length - 1),
       );


### PR DESCRIPTION
### 작업 내용
- 부위 탭(스쿼트, 데드, 벤치 등) 전환 시 브러쉬 범위가 이전 상태를 유지하던 문제 수정
- `prevActivePartRef`를 추가하여 `activePart.key` 변경 여부 추적
- 부위 전환 시 브러쉬 범위를 최신 데이터 기준으로 초기화
- 모바일 환경에서 브러쉬 슬라이드 영역에 `pointer-events: none` 적용

### 관련 이슈
- #108 