### PR TITLE
refactor: 운동 기록 리스트 레이아웃 구조 개선 및 반응형 스타일 수정

### DIFF
--- a/src/components/RecordList/RecordList.module.scss
+++ b/src/components/RecordList/RecordList.module.scss
@@ -8,11 +8,21 @@
   padding: 20px;
   width: 100%;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  .contentWrapper {
+    flex: 1;
+  }
 
   h1 {
     @include font-lg-title;
     color: $text-dark;
     margin-bottom: 20px;
+
+    @media (max-width: 400px) {
+      @include font-md-title;
+    }
 
     strong {
       color: $blue;
@@ -160,6 +170,7 @@
 
     td:nth-child(1) {
       grid-area: date;
+      background: $off-white;
     }
     td:nth-child(2) {
       grid-area: lift1;

--- a/src/components/RecordList/RecordList.tsx
+++ b/src/components/RecordList/RecordList.tsx
@@ -251,15 +251,18 @@ export default function RecordList({ userId }: RecordListProps) {
                 })}
               </tbody>
             </table>
-            <Pagination
-              totalCount={records.length}
-              pageSize={PAGE_SIZE}
-              currentPage={currentPage}
-              onPageChange={setCurrentPage}
-            />
           </div>
         )}
       </div>
+
+      {records.length > 0 && (
+        <Pagination
+          totalCount={records.length}
+          pageSize={PAGE_SIZE}
+          currentPage={currentPage}
+          onPageChange={setCurrentPage}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### 작업 내용
- `Pagination` 컴포넌트를 `listTable` 내부에서 `listContainer` 하위로 분리
- 기록이 없는 경우 `Pagination` 미렌더링 조건 추가
- `listContainer`에 flex 레이아웃 적용 및 `contentWrapper` 영역 분리
- `h1` 타이틀에 400px 이하 소형 기기 대응 폰트 크기 추가
- 모바일 카드 날짜 셀에 `off-white` 배경 적용으로 시각적 구분 강화