### PR TITLE
refactor: 로그인 상태에 따른 대시보드 레이아웃 분리

### DIFF
--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -16,16 +16,20 @@
   @media (min-width: 1300px) {
     grid-template-columns: repeat(2, 1fr);
     align-items: stretch;
+  }
+}
 
-    &.isGuest {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
+.guestGrid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+  margin-bottom: 20px;
 
-      & > div {
-        max-width: 600px;
-      }
-    }
+  & > div {
+    max-width: 600px;
+    width: 100%;
   }
 }
 
@@ -36,8 +40,4 @@
   background: $off-white;
   border: 1px solid $border-soft;
   border-radius: 15px;
-
-  @media (min-width: 1024px) {
-    grid-column: span 2;
-  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,24 +21,24 @@ export default function Home() {
     <div className={styles.pageContainer}>
       <NavBar href='/members' label='🔥 울끈불끈이들 기록 보러가기 🔥' />
 
-      <div className={`${styles.dashboardGrid} ${!user ? styles.isGuest : ''}`}>
-        <RecordForm />
-
-        {user ? (
-          <>
-            <ProfileCard />
-            <Charts />
-            <RecordList />
-          </>
-        ) : (
+      {user ? (
+        <div className={styles.dashboardGrid}>
+          <RecordForm />
+          <ProfileCard />
+          <Charts />
+          <RecordList />
+        </div>
+      ) : (
+        <div className={styles.guestGrid}>
+          <RecordForm />
           <div className={styles.guestMessage}>
             <Empty
               message='로그인 후 기록을 시작해 볼까요?'
               subMessage='나만의 운동 통계와 변화 그래프를 확인해 보세요.'
             />
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### 작업 내용
- 로그인/비로그인 상태에 따라 렌더링 분기 처리를 명확하게 분리
- 기존 `dashboardGrid`에 `isGuest` 조건부 클래스를 붙이던 방식 → 로그인 시 `dashboardGrid`, 비로그인 시 `guestGrid`로 완전히 분리
- `guestGrid` 스타일 클래스 신규 추가 (flex 레이아웃, max-width 600px 제한)
- `dashboardGrid`에서 `isGuest` 관련 스타일 제거로 단일 책임 원칙 준수