### PR TITLE
style: 반응형 레이아웃 및 타이포그래피 개선

### DIFF
--- a/src/app/members/[id]/MemberDetail.module.scss
+++ b/src/app/members/[id]/MemberDetail.module.scss
@@ -46,7 +46,7 @@
     }
 
     .title {
-      @include font-lg-title;
+      @include font-xl-title;
       text-align: center;
       gap: 8px;
       white-space: nowrap;

--- a/src/components/Charts/components/RecordChart/RecordChart.module.scss
+++ b/src/components/Charts/components/RecordChart/RecordChart.module.scss
@@ -7,8 +7,6 @@
   border-radius: $radius-main;
   padding: 20px;
   width: 100%;
-  overflow: hidden;
-  min-height: 500px;
 
   @media (max-width: 768px) {
     padding: 20px 10px;
@@ -26,6 +24,10 @@
     color: $text-dark;
     margin-bottom: 0;
 
+    @media (max-width: 400px) {
+      @include font-md-title;
+    }
+
     strong {
       color: $blue;
     }
@@ -37,6 +39,10 @@
     overflow-x: auto;
     padding-bottom: 5px;
     flex-wrap: nowrap;
+
+    @media (max-width: 768px) {
+      gap: 6px;
+    }
 
     &::-webkit-scrollbar {
       display: none;

--- a/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.module.scss
+++ b/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.module.scss
@@ -25,6 +25,10 @@
     color: $text-dark;
     margin-bottom: 0;
 
+    @media (max-width: 400px) {
+      @include font-md-title;
+    }
+
     strong {
       color: $blue;
     }
@@ -40,6 +44,10 @@
       @include font-body;
       color: $text-muted;
       margin-bottom: 0;
+
+      @media (max-width: 400px) {
+        @include font-sm;
+      }
     }
 
     .infoWrapper {
@@ -132,7 +140,6 @@
       flex-direction: column;
       gap: 10px;
       margin-top: 8px;
-      padding: 0 8px;
 
       .scoreItem {
         display: flex;

--- a/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.tsx
+++ b/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.tsx
@@ -228,7 +228,7 @@ export default function StrengthRadarChart({
           />
         ) : (
           <>
-            <ResponsiveContainer width='100%' height={280}>
+            <ResponsiveContainer width='100%' height={285}>
               <RadarChart
                 accessibilityLayer={false}
                 data={chartData}

--- a/src/components/Profile/Profile.module.scss
+++ b/src/components/Profile/Profile.module.scss
@@ -93,6 +93,10 @@
       padding: 0 24px 15px;
       display: flex;
       flex-direction: column;
+
+      @media (max-width: 768px) {
+        padding: 0 10px 15px;
+      }
     }
 
     .contentDetails {

--- a/src/components/Profile/components/StatsSection/StatsSection.module.scss
+++ b/src/components/Profile/components/StatsSection/StatsSection.module.scss
@@ -46,6 +46,10 @@
     grid-template-columns: repeat(4, 1fr);
     gap: 10px;
 
+    @media (max-width: 768px) {
+      gap: 5px;
+    }
+
     .recordsBox {
       text-align: center;
       display: flex;
@@ -56,6 +60,10 @@
       flex-direction: column;
       gap: 2px;
       overflow: hidden;
+
+      @media (max-width: 768px) {
+        padding: 10px;
+      }
 
       .recordsHeader {
         display: flex;

--- a/src/components/RecordForm/RecordForm.module.scss
+++ b/src/components/RecordForm/RecordForm.module.scss
@@ -14,6 +14,10 @@
   max-width: 100%;
   min-width: 0;
 
+  @media (max-width: 768px) {
+    padding: 2rem 1.5rem;
+  }
+
   .title {
     text-align: center;
     margin-bottom: 2.5rem;
@@ -45,7 +49,7 @@
 
         .repsWrapper {
           flex: 0.5;
-          min-width: 60px;
+          min-width: 45px;
           display: flex;
           align-items: center;
           gap: 2px;
@@ -74,7 +78,7 @@
 
         .statusInput {
           flex: 0.5;
-          min-width: 70px;
+          min-width: 75px;
           text-align: center;
 
           cursor: default;

--- a/src/components/RecordList/RecordList.module.scss
+++ b/src/components/RecordList/RecordList.module.scss
@@ -124,10 +124,10 @@
       display: grid;
       grid-template-columns: repeat(4, 1fr);
       grid-template-areas:
-        'manage manage manage manage'
         'date   date   date   date'
         'lift1  lift2  lift3  lift4'
-        'total  total  total  total';
+        'total  total  total  total'
+        'manage manage manage manage';
       background: $white;
       border: 1px solid $border-soft;
       border-radius: $radius-main;

--- a/src/components/shared/Empty/Empty.module.scss
+++ b/src/components/shared/Empty/Empty.module.scss
@@ -10,7 +10,7 @@
   white-space: nowrap;
 
   p {
-    @include font-body;
+    @include font-md-title;
     color: $text-dark;
     margin: 0;
   }
@@ -18,7 +18,7 @@
   span {
     display: block;
     margin-top: 8px;
-    @include font-sm;
+    @include font-body;
     color: $text-muted;
   }
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -6,7 +6,7 @@
 }
 
 body {
-  font-family: sans-serif;
+  font-family: var(--font-title), sans-serif;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
### 작업 내용
- `body` font-family에 CSS 변수(`--font-title`) 적용
- `formContainer` 모바일 좌우 패딩 축소, repsWrapper min-width 축소
- `recordsWrapper` 모바일 gap 및 패딩 축소
- `contentBox` 모바일 좌우 패딩 축소
- `chartContainer` min-height 및 overflow 제거, 소형 화면 폰트·gap 대응
- `StrengthRadarChart` 400px 이하 h1·subtitle 폰트 축소 대응
- `emptyContainer` p → font-md-title, span → font-body
- `MemberDetail` 타이틀 font-lg-title → font-xl-title
- `RadarChart` height 280 → 285
- 모바일 카드 grid-template-areas 순서 변경 (manage 하단 이동)