### PR TITLE
refactor: layout과 metadata 분리 및 Toaster 위치/속성 개선

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,54 +1,16 @@
-import type { Metadata, Viewport } from 'next';
 import { Toaster } from 'sonner';
-
-import styles from './layout.module.scss';
 
 import AuthForm from '@/components/AuthForm/AuthForm';
 import InstallBanner from '@/components/InstallBanner/InstallBanner';
 
+import QueryProvider from '@/providers/QueryProvider';
+
 import '@/styles/globals.scss';
 import { Font } from '@/styles/fonts';
 
-import QueryProvider from '@/providers/QueryProvider';
+import styles from './layout.module.scss';
 
-export const viewport: Viewport = {
-  themeColor: '#000000',
-  width: 'device-width',
-  initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
-};
-
-export const metadata: Metadata = {
-  title: '울끈불끈',
-  description: '울끈불끈 당신의 성장을 기록하세요.',
-  appleWebApp: {
-    capable: true,
-    statusBarStyle: 'black-translucent',
-    title: '울끈불끈',
-  },
-  icons: {
-    icon: '/assets/images/muscle.png',
-    apple: '/assets/images/muscle.png',
-  },
-
-  openGraph: {
-    title: '울끈불끈',
-    description: '울끈불끈 당신의 성장을 기록하세요.',
-    url: 'https://ulkunbulkun.vercel.app',
-    siteName: '울끈불끈',
-    images: [
-      {
-        url: '/assets/images/muscle_full_open_graph.png',
-        width: 1200,
-        height: 630,
-        alt: '울끈불끈 로고',
-      },
-    ],
-    locale: 'ko_KR',
-    type: 'website',
-  },
-};
+export { metadata, viewport } from './metadata';
 
 export default function RootLayout({
   children,
@@ -66,17 +28,18 @@ export default function RootLayout({
               {children}
             </main>
           </div>
-          <Toaster
-            position='top-center'
-            richColors
-            toastOptions={{
-              style: {
-                fontFamily: 'var(--font-title)',
-                fontSize: '18px',
-              },
-            }}
-          />
         </QueryProvider>
+        <Toaster
+          containerAriaLabel='알림'
+          position='top-center'
+          richColors
+          toastOptions={{
+            style: {
+              fontFamily: 'var(--font-title)',
+              fontSize: '18px',
+            },
+          }}
+        />
       </body>
     </html>
   );

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -1,0 +1,40 @@
+import type { Metadata, Viewport } from 'next';
+
+export const viewport: Viewport = {
+  themeColor: '#000000',
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+};
+
+export const metadata: Metadata = {
+  title: '울끈불끈',
+  description: '울끈불끈 당신의 성장을 기록하세요.',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'black-translucent',
+    title: '울끈불끈',
+  },
+  icons: {
+    icon: '/assets/images/muscle.png',
+    apple: '/assets/images/muscle.png',
+  },
+
+  openGraph: {
+    title: '울끈불끈',
+    description: '울끈불끈 당신의 성장을 기록하세요.',
+    url: 'https://ulkunbulkun.vercel.app',
+    siteName: '울끈불끈',
+    images: [
+      {
+        url: '/assets/images/muscle_full_open_graph.png',
+        width: 1200,
+        height: 630,
+        alt: '울끈불끈 로고',
+      },
+    ],
+    locale: 'ko_KR',
+    type: 'website',
+  },
+};


### PR DESCRIPTION
### 작업 내용
- layout.tsx에 정의되어 있던 `metadata`, `viewport`를 별도 파일(`metadata.ts`)로 분리
- `Toaster`를 `QueryProvider` 외부로 이동
- `Toaster`에 `containerAriaLabel` 속성 추가하여 접근성 개선