### PR TITLE
feat: PWA 초기 설정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
+import { withSerwist } from '@serwist/turbopack';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  turbopack: {},
 
   images: {
     remotePatterns: [
@@ -17,4 +19,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withSerwist(nextConfig);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,42 @@
+import { defaultCache } from '@serwist/turbopack/worker';
+import type { PrecacheEntry, SerwistGlobalConfig } from 'serwist';
+import { Serwist } from 'serwist';
+
+declare global {
+  interface WorkerGlobalScope extends SerwistGlobalConfig {
+    __SW_MANIFEST: (PrecacheEntry | string)[] | undefined;
+  }
+}
+
+declare const self: ServiceWorkerGlobalScope;
+
+const serwist = new Serwist({
+  precacheEntries: self.__SW_MANIFEST,
+  skipWaiting: true,
+  clientsClaim: true,
+  runtimeCaching: defaultCache,
+});
+
+self.addEventListener('push', (event) => {
+  let data: { title?: string; body?: string } = {};
+  try {
+    data = (event as PushEvent).data?.json() ?? {};
+  } catch {
+    data = { body: (event as PushEvent).data?.text() };
+  }
+
+  const title = data.title || '울끈불끈';
+  const options = {
+    body: data.body || '운동 기록을 남겨보세요!',
+    icon: '/assets/images/muscle.png',
+    badge: '/assets/images/muscle.png',
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  (event as NotificationEvent).notification.close();
+  event.waitUntil(self.clients.openWindow('/'));
+});
+
+serwist.addEventListeners();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext", "WebWorker"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
### 작업 내용
**Serwist PWA 설정**
- `@serwist/turbopack` 적용 및 `next.config.ts` 업데이트
- Turbopack 설정 추가

**TypeScript 설정**
- `tsconfig.json` lib에 `WebWorker` 타입 추가

**서비스 워커 구현**
- precache 설정 (`__SW_MANIFEST`)
- 푸시 알림 수신 및 표시 처리
- 알림 클릭 시 앱 포그라운드 이동 처리