### PR TITLE
feat: 알림 on/off 토글 커스텀 훅 구현

### DIFF
--- a/src/hooks/useNotificationToggle.ts
+++ b/src/hooks/useNotificationToggle.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import { supabase } from '@/lib/supabase';
+
+export function useNotificationToggle(userId?: string | null) {
+  const [isNotificationOn, setIsNotificationOn] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [toggling, setToggling] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!userId) {
+      setLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+
+    supabase
+      .from('push_subscriptions')
+      .select('is_active')
+      .eq('user_id', userId)
+      .maybeSingle()
+      .then(({ data, error }) => {
+        if (!isMounted) return;
+
+        if (error) {
+          console.error('알림 상태 조회 실패:', error);
+        }
+
+        setIsNotificationOn(data?.is_active ?? true);
+        setLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [userId]);
+
+  const toggle = async () => {
+    if (!userId || toggling) return;
+
+    const next = !isNotificationOn;
+    setToggling(true);
+
+    const { data, error } = await supabase
+      .from('push_subscriptions')
+      .update({ is_active: next })
+      .eq('user_id', userId)
+      .select('user_id');
+
+    setToggling(false);
+
+    if (error) {
+      console.error('알림 상태 변경 실패:', error);
+      toast.error('알림 설정을 변경하지 못했어요. 잠시 후 다시 시도해주세요.');
+      return;
+    }
+
+    if (!data || data.length === 0) {
+      toast.error('푸시 알림을 먼저 허용해주세요.');
+      return;
+    }
+
+    setIsNotificationOn(next);
+    toast.info(next ? '전체 알림을 켰어요!' : '전체 알림을 껐어요!');
+  };
+
+  return { isNotificationOn, loading, toggling, toggle };
+}


### PR DESCRIPTION
### 작업 내용
- push_subscriptions 테이블의 is_active 값을 조회/업데이트
- userId가 없을 경우 기본값(true)으로 처리
- 토글 중 중복 호출 방지 처리
- 업데이트 실패 및 미구독(row 없음) 케이스에 대한 에러 처리 추가
- 토글 성공 시 sonner 토스트로 알림 상태 안내