### PR TITLE
feat: 팔로우 토글 및 캐시 동기화 훅 구현

### DIFF
--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { supabase } from '@/lib/supabase';
+
+export function useSubscription(targetId?: string, myId?: string) {
+  const queryClient = useQueryClient();
+
+  const [isSubscribed, setIsSubscribed] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (!targetId || !myId || targetId === myId) {
+      setLoading(false);
+      return;
+    }
+
+    supabase
+      .from('subscriptions')
+      .select('id')
+      .eq('subscriber_id', myId)
+      .eq('target_id', targetId)
+      .maybeSingle()
+      .then(({ data }) => {
+        setIsSubscribed(!!data);
+        setLoading(false);
+      });
+  }, [targetId, myId]);
+
+  const toggle = async () => {
+    if (!targetId || !myId) return;
+
+    if (isSubscribed) {
+      const { error } = await supabase
+        .from('subscriptions')
+        .delete()
+        .eq('subscriber_id', myId)
+        .eq('target_id', targetId);
+
+      if (!error) {
+        setIsSubscribed(false);
+        toast.info('구독을 취소했어요.');
+
+        queryClient.setQueryData<Set<string>>(
+          ['mySubscriptions', myId],
+          (prev) => {
+            const next = new Set(prev ?? []);
+            next.delete(targetId);
+            return next;
+          },
+        );
+
+        queryClient.setQueryData<Set<string>>(
+          ['mySubscribers', targetId],
+          (prev) => {
+            const next = new Set(prev ?? []);
+            next.delete(myId);
+            return next;
+          },
+        );
+      }
+    } else {
+      const { error } = await supabase
+        .from('subscriptions')
+        .insert({ subscriber_id: myId, target_id: targetId });
+
+      if (!error) {
+        setIsSubscribed(true);
+        toast.info('구독을 시작했어요!');
+
+        queryClient.setQueryData<Set<string>>(
+          ['mySubscriptions', myId],
+          (prev) => new Set(prev ?? []).add(targetId),
+        );
+        queryClient.setQueryData<Set<string>>(
+          ['mySubscribers', targetId],
+          (prev) => new Set(prev ?? []).add(myId),
+        );
+
+        fetch('/api/notify-new-subscriber', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-internal-secret':
+              process.env.NEXT_PUBLIC_INTERNAL_API_SECRET || '',
+          },
+          body: JSON.stringify({ subscriber_id: myId, target_id: targetId }),
+        }).catch((err) => console.error('구독 알림 에러:', err));
+      }
+    }
+  };
+
+  return { isSubscribed, loading, toggle };
+}


### PR DESCRIPTION
### 작업 내용
- supabase subscriptions 테이블 조회로 팔로우 여부 확인
- 팔로우/팔로우 취소 시 react-query 캐시(mySubscriptions, mySubscribers) 낙관적 업데이트
- 팔로우 시 신규 팔로워 알림 API(/api/notify-new-subscriber) 비동기 호출
- 팔로우/팔로우 취소 결과를 토스트로 안내