### PR TITLE
feat: 팔로워 목록 조회 훅 구현

### DIFF
--- a/src/hooks/useMySubscribers.ts
+++ b/src/hooks/useMySubscribers.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { supabase } from '@/lib/supabase';
+
+export function useMySubscribers(myId?: string) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['mySubscribers', myId],
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('subscriptions')
+        .select('subscriber_id')
+        .eq('target_id', myId!);
+      return new Set((data ?? []).map((row) => row.subscriber_id));
+    },
+    enabled: !!myId,
+  });
+
+  return { subscriberIds: data ?? new Set<string>(), loading: isLoading };
+}


### PR DESCRIPTION
### 작업 내용
- target_id 기준으로 subscriptions 테이블에서 구독자 id 목록을 조회
- 조회 결과를 Set으로 변환하여 반환
- myId가 없을 경우 쿼리 비활성화 처리