### PR TITLE
feat: 내 팔로잉 조회 훅 구현

### DIFF
--- a/src/hooks/useMySubscriptions.ts
+++ b/src/hooks/useMySubscriptions.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { supabase } from '@/lib/supabase';
+
+export function useMySubscriptions(myId?: string) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['mySubscriptions', myId],
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('subscriptions')
+        .select('target_id')
+        .eq('subscriber_id', myId!);
+      return new Set((data ?? []).map((row) => row.target_id));
+    },
+    enabled: !!myId,
+  });
+
+  return { subscribedIds: data ?? new Set<string>(), loading: isLoading };
+}


### PR DESCRIPTION
### 작업 내용
- supabase subscriptions 테이블에서 subscriber_id 기준으로 target_id 조회
- react-query로 캐싱 및 로딩 상태 관리
- 조회 결과를 Set으로 변환하여 팔로잉 여부 확인 용이