### PR TITLE
feat: 신규 팔로워 발생 웹 푸시 알림 전송 API 구현

### DIFF
--- a/src/app/api/notify-new-subscriber/route.ts
+++ b/src/app/api/notify-new-subscriber/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import webpush from 'web-push';
+
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+webpush.setVapidDetails(
+  'mailto:eogus2604@gmail.com',
+  process.env.VAPID_PUBLIC_KEY!,
+  process.env.VAPID_PRIVATE_KEY!,
+);
+
+export async function POST(req: NextRequest) {
+  const secret = req.headers.get('x-internal-secret');
+  if (secret !== process.env.INTERNAL_API_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { subscriber_id, target_id } = await req.json();
+
+  if (!subscriber_id || !target_id) {
+    return NextResponse.json(
+      { error: 'subscriber_id, target_id is required' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    // 나를 팔로우한 사람(팔로워)의 닉네임 조회
+    const { data: subscriberProfile } = await supabaseAdmin
+      .from('profiles')
+      .select('nickname')
+      .eq('id', subscriber_id)
+      .single();
+
+    // 팔로우 당한 사람(팔로잉)의 웹 푸시 알림 구독 정보 조회
+    const { data: pushSub, error: pushError } = await supabaseAdmin
+      .from('push_subscriptions')
+      .select('subscription')
+      .eq('user_id', target_id)
+      .eq('is_active', true)
+      .maybeSingle();
+
+    if (pushError) throw pushError;
+    if (!pushSub) {
+      return NextResponse.json({ ok: true, notified: 0 });
+    }
+
+    // 알림 발송
+    await webpush.sendNotification(
+      pushSub.subscription as any,
+      JSON.stringify({
+        title: '새로운 팔로워!',
+        body: `${subscriberProfile?.nickname ?? '울끈불끈이'}님이 나를 팔로우했어요 🔔`,
+        url: `/members/${subscriber_id}`,
+      }),
+    );
+
+    return NextResponse.json({ ok: true, notified: 1 });
+  } catch (error) {
+    console.error('Notify new subscriber error:', error);
+    return NextResponse.json({ error: 'Failed to notify' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
### 작업 내용
- `web-push` 라이브러리를 활용한 VAPID 기반 푸시 알림 설정
- `x-internal-secret` 헤더를 통한 내부 API 접근 제어
- `push_subscriptions` 테이블에서 활성 구독 정보 조회
- 팔로워 닉네임을 포함한 푸시 알림 메시지 발송
