### PR TITLE
feat: 프로필 팔로우 및 알림 기능 추가

### DIFF
--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -20,6 +20,8 @@ import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { useRecords } from '@/hooks/useRecords';
 import { useProfileUpdate } from '@/hooks/useProfileUpdate';
+import { useSubscription } from '@/hooks/useSubscription';
+import { useNotificationToggle } from '@/hooks/useNotificationToggle';
 
 import { calculateTotalPR } from '@/utils/recordUtils';
 
@@ -46,8 +48,16 @@ export default function ProfileCard({
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [stage, setStage] = useState<1 | 2>(1);
 
+  const { isSubscribed, toggle: handleSubscribe } = useSubscription(
+    targetId,
+    user?.id,
+  );
+
   const isMyProfile = !userId || userId === user?.id;
   const canEdit = isMyProfile && user && !readOnly;
+
+  const { isNotificationOn, toggle: handleNotificationToggle } =
+    useNotificationToggle(isMyProfile ? user?.id : null);
 
   const queryClient = useQueryClient();
 
@@ -189,8 +199,13 @@ export default function ProfileCard({
                     setIsEditing(true);
                   }}
                   onTogglePublic={handleTogglePublic}
+                  onSubscribe={handleSubscribe}
+                  onToggleNotification={handleNotificationToggle}
                   isPublic={profile?.is_public}
+                  isSubscribed={isSubscribed}
+                  isNotificationOn={isNotificationOn}
                   readOnly={!canEdit}
+                  isMyProfile={isMyProfile}
                 />
               </div>
             )}

--- a/src/components/Profile/components/ActionsSection/ActionsSection.module.scss
+++ b/src/components/Profile/components/ActionsSection/ActionsSection.module.scss
@@ -5,10 +5,14 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  gap: 4px;
+  gap: 10px;
   padding: 15px 0 0 0;
   border-top: 1px solid $border-soft;
   overflow: hidden;
+
+  @media (max-width: 768px) {
+    gap: 5px;
+  }
 
   button {
     flex: 1;

--- a/src/components/Profile/components/ActionsSection/ActionsSection.tsx
+++ b/src/components/Profile/components/ActionsSection/ActionsSection.tsx
@@ -1,6 +1,15 @@
 'use client';
 
-import { Edit, Share2, Bell, Eye, EyeOff } from 'lucide-react';
+import {
+  Edit,
+  Share2,
+  Bell,
+  BellOff,
+  Eye,
+  EyeOff,
+  UserRoundPlus,
+  UserRoundCheck,
+} from 'lucide-react';
 
 import styles from './ActionsSection.module.scss';
 
@@ -10,16 +19,26 @@ type ActionsSectionProps = {
   onShare?: () => void;
   onEditProfile?: () => void;
   onTogglePublic?: () => void;
+  onSubscribe?: () => void;
+  onToggleNotification?: () => void;
   isPublic?: boolean;
+  isSubscribed?: boolean;
+  isNotificationOn?: boolean;
   readOnly?: boolean;
+  isMyProfile?: boolean;
 };
 
 export default function ActionsSection({
   onShare,
   onEditProfile,
   onTogglePublic,
+  onSubscribe,
+  onToggleNotification,
   isPublic,
+  isSubscribed,
+  isNotificationOn,
   readOnly,
+  isMyProfile,
 }: ActionsSectionProps) {
   return (
     <section className={styles.actionContainer}>
@@ -35,16 +54,35 @@ export default function ActionsSection({
         공유
       </Button>
 
+      {readOnly && !isMyProfile && (
+        <Button variant='outline' active={isSubscribed} onClick={onSubscribe}>
+          {isSubscribed ? (
+            <UserRoundCheck size={16} strokeWidth={2} />
+          ) : (
+            <UserRoundPlus size={16} strokeWidth={2} />
+          )}
+          {isSubscribed ? '팔로잉' : '팔로우'}
+        </Button>
+      )}
+
       {!readOnly && (
         <>
-          <Button variant='outline' disabled>
-            <Bell size={16} strokeWidth={2} />
-            알림
-          </Button>
-
-          <Button variant='outline' onClick={onTogglePublic}>
+          <Button variant='outline' active={isPublic} onClick={onTogglePublic}>
             {isPublic ? <Eye size={16} /> : <EyeOff size={16} />}
             {isPublic ? '공개' : '비공개'}
+          </Button>
+
+          <Button
+            variant='outline'
+            active={isNotificationOn}
+            onClick={onToggleNotification}
+          >
+            {isNotificationOn ? (
+              <Bell size={16} strokeWidth={2} />
+            ) : (
+              <BellOff size={16} strokeWidth={2} />
+            )}
+            {isNotificationOn ? '알림 켬' : '알림 끔'}
           </Button>
         </>
       )}

--- a/src/components/shared/Button/Button.module.scss
+++ b/src/components/shared/Button/Button.module.scss
@@ -70,8 +70,18 @@
   color: $text-dark;
 
   &:hover:not(:disabled) {
-    background: $ligray;
-    border-color: $border-liblue;
+    border-color: $blue;
+    color: $blue;
+  }
+
+  &.active {
+    background: $blue;
+    border-color: $blue;
+    color: $white;
+
+    &:hover:not(:disabled) {
+      color: $white;
+    }
   }
 }
 

--- a/src/components/shared/Button/Button.tsx
+++ b/src/components/shared/Button/Button.tsx
@@ -4,6 +4,7 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: 'gray' | 'red' | 'ligray' | 'blue' | 'white' | 'outline';
   size?: 'sm' | 'md' | 'lg';
   shape?: 'square' | 'round';
+  active?: boolean;
 };
 
 export default function Button({
@@ -11,12 +12,13 @@ export default function Button({
   variant = 'gray',
   size = 'md',
   shape = 'square',
+  active,
   className,
   ...props
 }: ButtonProps) {
   return (
     <button
-      className={`${styles.button} ${styles[variant]} ${styles[size]} ${styles[shape]} ${className || ''}`}
+      className={`${styles.button} ${styles[variant]} ${styles[size]} ${styles[shape]} ${active ? styles.active : ''} ${className || ''}`}
       {...props}
     >
       {children}


### PR DESCRIPTION
### 작업 내용
**`ActionsSection`**
- 타인 프로필 조회 시 팔로우/팔로잉 버튼 추가 (`isMyProfile` 분기 처리)
- 알림 버튼을 토글 가능한 상태로 개선 (`Bell` ↔ `BellOff`)
- 공개/비공개 버튼 `active` 상태 반영
- 관련 props 및 핸들러 추가 (`onSubscribe`, `onToggleNotification`, `isSubscribed`, `isNotificationOn`, `isMyProfile`) 처리
- 버튼 간격 `gap` 조정
- 모바일 환경 별도 `gap` 적용

**`ProfileCard`**
- `useSubscription`, `useNotificationToggle` 훅 연동
- `ActionsSection`에 팔로우 및 알림 관련 props 전달

**`Button`**
- `active` prop 추가 및 활성 상태 클래스 바인딩
- `outline` variant hover 스타일 변경
- `outline` variant `active` 상태 스타일 추가
- 버튼 간격 `gap` 조정
- 모바일 환경 별도 `gap` 적용 