### PR TITLE
feat: 멤버 목록 페이지 팔로우 기반 필터 및 배지 기능 추가

### DIFF
--- a/src/app/members/Members.module.scss
+++ b/src/app/members/Members.module.scss
@@ -22,3 +22,13 @@
     }
   }
 }
+
+.filterTabs {
+  @include flex-center;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+
+  button {
+    color: $text-muted;
+  }
+}

--- a/src/app/members/components/UserCard/UserCard.module.scss
+++ b/src/app/members/components/UserCard/UserCard.module.scss
@@ -61,6 +61,14 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 150px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    .subscribedBadge {
+      flex-shrink: 0;
+      color: $blue;
+    }
   }
 
   .userStats {

--- a/src/app/members/components/UserCard/UserCard.tsx
+++ b/src/app/members/components/UserCard/UserCard.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { UserRoundCheck } from 'lucide-react';
 
 import styles from './UserCard.module.scss';
 
@@ -10,9 +11,10 @@ import { getDisplayDate, getCombinedTotalFromUser } from '@/utils/recordUtils';
 
 type UserCardProps = {
   user: UserSummary;
+  isSubscribed?: boolean;
 };
 
-export default function UserCard({ user }: UserCardProps) {
+export default function UserCard({ user, isSubscribed }: UserCardProps) {
   const isPrivate = user.is_public === false;
 
   const cardContent = (
@@ -34,7 +36,12 @@ export default function UserCard({ user }: UserCardProps) {
 
       <div className={styles.userInfo}>
         <p className={styles.statusMessage}>{user.status_message}</p>
-        <h3 className={styles.userName}>{user.nickname}</h3>
+        <h3 className={styles.userName}>
+          {user.nickname}
+          {isSubscribed && (
+            <UserRoundCheck size={18} className={styles.subscribedBadge} />
+          )}
+        </h3>
         <p className={styles.userStats}>
           PR:<span>{getCombinedTotalFromUser(user)}</span>
         </p>

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import styles from './Members.module.scss';
 
@@ -9,14 +9,33 @@ import UserCard from './components/UserCard/UserCard';
 import Pagination from '@/components/shared/Pagination/Pagination';
 import Loading from '@/components/shared/Loading/Loading';
 import NavBar from '@/components/shared/NavBar/NavBar';
+import Button from '@/components/shared/Button/Button';
 
 import { useUsers } from '@/hooks/useUsers';
+import { useAuth } from '@/hooks/useAuth';
+import { useMySubscriptions } from '@/hooks/useMySubscriptions';
+import { useMySubscribers } from '@/hooks/useMySubscribers';
 
 const PAGE_SIZE = 8;
 
+type FilterType = 'all' | 'subscribed' | 'subscribers';
+
 export default function MembersPage() {
+  const { user } = useAuth();
+
   const { users, loading } = useUsers();
+  const { subscribedIds, loading: subsLoading } = useMySubscriptions(user?.id);
+  const { subscriberIds, loading: subscribersLoading } = useMySubscribers(
+    user?.id,
+  );
+
   const [currentPage, setCurrentPage] = useState<number>(1);
+  const [filter, setFilter] = useState<FilterType>('all');
+
+  // 로그아웃 시 필터 초기화
+  useEffect(() => {
+    if (!user) setFilter('all');
+  }, [user]);
 
   const sortedUsers = useMemo(() => {
     return [...users].sort((a, b) => {
@@ -34,14 +53,29 @@ export default function MembersPage() {
     });
   }, [users]);
 
+  const filteredUsers = useMemo(() => {
+    if (filter === 'subscribed') {
+      return sortedUsers.filter((user) => subscribedIds.has(user.id));
+    }
+    if (filter === 'subscribers') {
+      return sortedUsers.filter((u) => subscriberIds.has(u.id));
+    }
+    return sortedUsers;
+  }, [sortedUsers, filter, subscribedIds, subscriberIds]);
+
   const paginatedUsers = useMemo(() => {
-    return sortedUsers.slice(
+    return filteredUsers.slice(
       (currentPage - 1) * PAGE_SIZE,
       currentPage * PAGE_SIZE,
     );
-  }, [sortedUsers, currentPage]);
+  }, [filteredUsers, currentPage]);
 
-  if (loading)
+  const handleFilterChange = (next: FilterType) => {
+    setFilter(next);
+    setCurrentPage(1);
+  };
+
+  if (loading || subsLoading || subscribersLoading)
     return <Loading fullHeight={true} message='울끈불끈이들 입장 중!' />;
 
   return (
@@ -49,14 +83,48 @@ export default function MembersPage() {
       <NavBar href='/' label='대시보드로 돌아가기' />
       <h1 className={styles.title}>🔥 울끈불끈이들 🔥</h1>
 
+      {user && (
+        <div className={styles.filterTabs}>
+          <Button
+            variant='outline'
+            shape='round'
+            color='muted'
+            active={filter === 'all'}
+            onClick={() => handleFilterChange('all')}
+          >
+            전체보기
+          </Button>
+          <Button
+            variant='outline'
+            shape='round'
+            active={filter === 'subscribers'}
+            onClick={() => handleFilterChange('subscribers')}
+          >
+            팔로워 {subscriberIds.size}
+          </Button>
+          <Button
+            variant='outline'
+            shape='round'
+            active={filter === 'subscribed'}
+            onClick={() => handleFilterChange('subscribed')}
+          >
+            팔로잉 {subscribedIds.size}
+          </Button>
+        </div>
+      )}
+
       <div className={styles.userGrid}>
-        {paginatedUsers.map((user) => (
-          <UserCard key={user.id} user={user} />
+        {paginatedUsers.map((u) => (
+          <UserCard
+            key={u.id}
+            user={u}
+            isSubscribed={subscribedIds.has(u.id)}
+          />
         ))}
       </div>
 
       <Pagination
-        totalCount={sortedUsers.length}
+        totalCount={filteredUsers.length}
         pageSize={PAGE_SIZE}
         currentPage={currentPage}
         onPageChange={setCurrentPage}


### PR DESCRIPTION
### 작업 내용
**`UserCard`**
- `isSubscribed` prop 추가
- 팔로우 중인 유저 닉네임 옆에 `UserRoundCheck` 아이콘 배지 표시
- `.userName`에 flex 레이아웃 적용 및 `.subscribedBadge` 스타일 추가

**`Members`**
- `useMySubscriptions`, `useMySubscribers` 훅 연동
- 전체 / 팔로워 / 팔로잉 필터 탭 UI 추가
- 필터 변경 시 페이지 1로 초기화
- 로그아웃 시 필터 자동 초기화 (`useEffect`)
- `UserCard`에 `isSubscribed` prop 전달
- `.filterTabs` 스타일 추가