### PR TITLE
feat: 운동 기록 차트 부위 선택 버튼 스타일 개선 

### DIFF
--- a/src/components/Charts/components/RecordChart/RecordChart.module.scss
+++ b/src/components/Charts/components/RecordChart/RecordChart.module.scss
@@ -153,8 +153,18 @@
     white-space: nowrap;
     flex-shrink: 0;
 
+    &:hover:not(:disabled) {
+      color: var(--part-color);
+      border-color: var(--part-color);
+      background: transparent;
+    }
+
     &.active {
       color: $white;
+
+      &:hover:not(:disabled) {
+        color: $white;
+      }
     }
   }
 

--- a/src/components/Charts/components/RecordChart/RecordChart.tsx
+++ b/src/components/Charts/components/RecordChart/RecordChart.tsx
@@ -279,15 +279,18 @@ export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
                 <Button
                   type='button'
                   key={part.key}
-                  variant='ligray'
+                  variant='outline'
                   size='sm'
                   shape='round'
                   onClick={() => setActivePart(part)}
                   className={`${styles.partBtn} ${isActive ? styles.active : ''}`}
-                  style={{
-                    backgroundColor: isActive ? part.color : '',
-                    borderColor: isActive ? part.color : '',
-                  }}
+                  style={
+                    {
+                      backgroundColor: isActive ? part.color : '',
+                      borderColor: isActive ? part.color : '',
+                      '--part-color': part.color,
+                    } as React.CSSProperties
+                  }
                 >
                   {part.label}
                 </Button>


### PR DESCRIPTION
### 작업 내용
- 부위 선택 버튼 variant를 `ligray` → `outline`으로 변경
- CSS 변수(`--part-color`)를 통해 부위별 색상을 버튼에 주입
- 비활성 버튼 호버 시 해당 부위 색상으로 텍스트 및 테두리 강조
- 활성 버튼 호버 시 흰색 텍스트 유지