### PR TITLE
feat: 비로그인 사용자 팔로우 버튼 미노출 처리

### DIFF
--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -55,6 +55,7 @@ export default function ProfileCard({
 
   const isMyProfile = !userId || userId === user?.id;
   const canEdit = isMyProfile && user && !readOnly;
+  const isLoggedIn = !!user;
 
   const { isNotificationOn, toggle: handleNotificationToggle } =
     useNotificationToggle(isMyProfile ? user?.id : null);
@@ -205,6 +206,7 @@ export default function ProfileCard({
                   isSubscribed={isSubscribed}
                   isNotificationOn={isNotificationOn}
                   readOnly={!canEdit}
+                  isLoggedIn={isLoggedIn}
                   isMyProfile={isMyProfile}
                 />
               </div>

--- a/src/components/Profile/components/ActionsSection/ActionsSection.tsx
+++ b/src/components/Profile/components/ActionsSection/ActionsSection.tsx
@@ -26,6 +26,7 @@ type ActionsSectionProps = {
   isNotificationOn?: boolean;
   readOnly?: boolean;
   isMyProfile?: boolean;
+  isLoggedIn?: boolean;
 };
 
 export default function ActionsSection({
@@ -39,6 +40,7 @@ export default function ActionsSection({
   isNotificationOn,
   readOnly,
   isMyProfile,
+  isLoggedIn,
 }: ActionsSectionProps) {
   return (
     <section className={styles.actionContainer}>
@@ -54,7 +56,7 @@ export default function ActionsSection({
         공유
       </Button>
 
-      {readOnly && !isMyProfile && (
+      {readOnly && !isMyProfile && isLoggedIn && (
         <Button variant='outline' active={isSubscribed} onClick={onSubscribe}>
           {isSubscribed ? (
             <UserRoundCheck size={16} strokeWidth={2} />


### PR DESCRIPTION
## 작업 내용
- `ProfileCard` 로그인 여부(`isLoggedIn`) `ActionsSection`에 전달
- `ActionsSection` `isLoggedIn` prop 추가, 비로그인 시 팔로우 버튼 미노출 처리