### PR TITLE
refactor: 구독 알림 API 인증 방식 내부 시크릿에서 Bearer 토큰으로 변경

### DIFF
--- a/src/app/api/notify-new-subscriber/route.ts
+++ b/src/app/api/notify-new-subscriber/route.ts
@@ -10,12 +10,21 @@ webpush.setVapidDetails(
 );
 
 export async function POST(req: NextRequest) {
-  const secret = req.headers.get('x-internal-secret');
-  if (secret !== process.env.INTERNAL_API_SECRET) {
+  const token = req.headers.get('Authorization')?.replace('Bearer ', '');
+  if (!token) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { subscriber_id, target_id } = await req.json();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabaseAdmin.auth.getUser(token);
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+  }
+
+  const subscriber_id = user.id;
+  const { target_id } = await req.json();
 
   if (!subscriber_id || !target_id) {
     return NextResponse.json(

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -80,14 +80,17 @@ export function useSubscription(targetId?: string, myId?: string) {
           (prev) => new Set(prev ?? []).add(myId),
         );
 
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+
         fetch('/api/notify-new-subscriber', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'x-internal-secret':
-              process.env.NEXT_PUBLIC_INTERNAL_API_SECRET || '',
+            Authorization: `Bearer ${session?.access_token ?? ''}`,
           },
-          body: JSON.stringify({ subscriber_id: myId, target_id: targetId }),
+          body: JSON.stringify({ target_id: targetId }),
         }).catch((err) => console.error('구독 알림 에러:', err));
       }
     }


### PR DESCRIPTION
### 작업 내용
- `x-internal-secret` 헤더 기반 인증 제거
- `Authorization: Bearer {token}` 헤더로 인증 방식 변경
- `supabaseAdmin.auth.getUser(token)`으로 사용자 검증 및 `subscriber_id` 서버에서 추출
- `NEXT_PUBLIC_INTERNAL_API_SECRET` 환경변수 참조 제거
- `supabase.auth.getSession()`으로 액세스 토큰 취득 후 요청 헤더에 포함
- 요청 바디에서 `subscriber_id` 제거 (서버에서 토큰으로 식별)