### PR TITLE
refactor: 팔로워 알림 API 인증 방식 내부 시크릿에서 Bearer 토큰으로 변경

### DIFF
--- a/src/app/api/notify-followers/route.ts
+++ b/src/app/api/notify-followers/route.ts
@@ -11,16 +11,20 @@ webpush.setVapidDetails(
 
 export async function POST(req: NextRequest) {
   // 내부 호출(DB 트리거)인지 검증
-  const secret = req.headers.get('x-internal-secret');
-  if (secret !== process.env.INTERNAL_API_SECRET) {
+  const token = req.headers.get('Authorization')?.replace('Bearer ', '');
+  if (!token) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { user_id } = await req.json();
-
-  if (!user_id) {
-    return NextResponse.json({ error: 'user_id is required' }, { status: 400 });
+  const {
+    data: { user },
+    error: authError,
+  } = await supabaseAdmin.auth.getUser(token);
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
   }
+
+  const user_id = user.id;
 
   try {
     // 해당 유저를 팔로우한 사람들 조회

--- a/src/hooks/useRecordForm.ts
+++ b/src/hooks/useRecordForm.ts
@@ -250,14 +250,16 @@ export function useRecordForm({
       if (updateError) throw updateError;
 
       // 알림 API 라우트 호출
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
       fetch('/api/notify-followers', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-internal-secret':
-            process.env.NEXT_PUBLIC_INTERNAL_API_SECRET || '',
+          Authorization: `Bearer ${session?.access_token ?? ''}`,
         },
-        body: JSON.stringify({ user_id: user.id }),
       }).catch((err) => console.error('알림 네트워크 에러:', err));
 
       // 성공 피드백 및 상태 초기화


### PR DESCRIPTION
### 작업 내용
- `x-internal-secret` 헤더 기반 인증 제거
- `Authorization: Bearer {token}` 헤더로 인증 방식 변경
- `supabaseAdmin.auth.getUser(token)`으로 사용자 검증 및 `user_id` 서버에서 추출
- `NEXT_PUBLIC_INTERNAL_API_SECRET` 환경변수 참조 제거
- `supabase.auth.getSession()`으로 액세스 토큰 취득 후 요청 헤더에 포함
- 요청 바디에서 `user_id` 제거 (서버에서 토큰으로 식별)