### PR TITLE
feat: 멤버 목록 구독 뱃지 클릭 시 언팔로우 기능 추가

### DIFF
--- a/src/app/members/components/UserCard/UserCard.module.scss
+++ b/src/app/members/components/UserCard/UserCard.module.scss
@@ -65,9 +65,29 @@
     align-items: center;
     gap: 6px;
 
+    .subscribedBadgeBtn {
+      flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: none;
+      border: none;
+      padding: 2px;
+      margin: 0;
+      cursor: pointer;
+      line-height: 0;
+      border-radius: 4px;
+      transition: $transition-base;
+
+      &:hover {
+        background: rgba($blue, 0.1);
+      }
+    }
+
     .subscribedBadge {
       flex-shrink: 0;
       color: $blue;
+      pointer-events: none;
     }
   }
 

--- a/src/app/members/components/UserCard/UserCard.tsx
+++ b/src/app/members/components/UserCard/UserCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import Image from 'next/image';
 import { UserRoundCheck } from 'lucide-react';
@@ -9,6 +11,10 @@ import { UserSummary } from '@/types/user';
 import { formatDate } from '@/utils/dateUtils';
 import { getDisplayDate, getCombinedTotalFromUser } from '@/utils/recordUtils';
 
+import { useAuth } from '@/hooks/useAuth';
+import { useSubscription } from '@/hooks/useSubscription';
+import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
+
 type UserCardProps = {
   user: UserSummary;
   isSubscribed?: boolean;
@@ -16,6 +22,18 @@ type UserCardProps = {
 
 export default function UserCard({ user, isSubscribed }: UserCardProps) {
   const isPrivate = user.is_public === false;
+
+  const { user: currentUser } = useAuth();
+  const { toggle } = useSubscription(user.id, currentUser?.id);
+
+  const handleUnsubscribeClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    ConfirmToast(`${user.nickname}님 팔로우를 취소할까요?`, () => {
+      toggle();
+    });
+  };
 
   const cardContent = (
     <>
@@ -39,7 +57,14 @@ export default function UserCard({ user, isSubscribed }: UserCardProps) {
         <h3 className={styles.userName}>
           {user.nickname}
           {isSubscribed && (
-            <UserRoundCheck size={18} className={styles.subscribedBadge} />
+            <button
+              type='button'
+              aria-label='팔로우 취소'
+              className={styles.subscribedBadgeBtn}
+              onClick={handleUnsubscribeClick}
+            >
+              <UserRoundCheck size={18} className={styles.subscribedBadge} />
+            </button>
           )}
         </h3>
         <p className={styles.userStats}>


### PR DESCRIPTION
### 작업 내용
- 구독 뱃지 아이콘을 `button`으로 감싸 클릭 가능하도록 변경
- `useAuth`, `useSubscription` 훅을 사용해 현재 로그인한 사용자 기준으로 구독 상태 토글 처리
- 뱃지 클릭 시 `ConfirmToast`로 언팔로우 확인 절차 추가
- 카드 클릭(상세페이지 이동)과 이벤트가 겹치지 않도록 `preventDefault`, `stopPropagation` 처리
- 클라이언트 컴포넌트로 전환 (`'use client'` 추가)