### PR TITLE
feat: 프로필 weight 필드 추가

### DIFF
--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -7,6 +7,7 @@ export type ProfileData = {
   avatar_url: string;
   status_message: string;
   is_public: boolean;
+  weight: number | null;
 };
 
 export function useProfile(userId: string | undefined) {
@@ -17,7 +18,7 @@ export function useProfile(userId: string | undefined) {
 
       const { data, error } = await supabase
         .from('profiles')
-        .select('nickname, avatar_url, status_message, is_public')
+        .select('nickname, avatar_url, status_message, is_public, weight')
         .eq('id', userId)
         .single();
 
@@ -25,13 +26,13 @@ export function useProfile(userId: string | undefined) {
 
       return {
         nickname: data.nickname || '울끈불끈이',
-
         avatar_url:
           data.avatar_url && data.avatar_url.trim() !== ''
             ? data.avatar_url
             : undefined,
         status_message: data.status_message || '울끈불끈!',
         is_public: data.is_public ?? true,
+        weight: data.weight ?? null,
       };
     },
     enabled: !!userId,

--- a/src/hooks/useProfileUpdate.ts
+++ b/src/hooks/useProfileUpdate.ts
@@ -55,6 +55,7 @@ export function useProfileUpdate(user: User) {
     status: string,
     avatarUrl: string,
     isPublic: boolean,
+    weight?: number | null,
   ) => {
     try {
       const { error } = await supabase.from('profiles').upsert({
@@ -63,6 +64,7 @@ export function useProfileUpdate(user: User) {
         status_message: status || '울끈불끈!',
         avatar_url: avatarUrl,
         is_public: isPublic,
+        weight: weight ?? null,
         updated_at: new Date().toISOString(),
       });
 
@@ -87,6 +89,7 @@ export function useProfileUpdate(user: User) {
         status_message: '울끈불끈!',
         avatar_url: originalAvatar,
         is_public: true,
+        weight: null,
         updated_at: new Date().toISOString(),
       });
 

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -42,7 +42,7 @@ export function useSubscription(targetId?: string, myId?: string) {
 
       if (!error) {
         setIsSubscribed(false);
-        toast.info('구독을 취소했어요.');
+        toast.info('팔로우를 취소했어요.');
 
         queryClient.setQueryData<Set<string>>(
           ['mySubscriptions', myId],
@@ -69,7 +69,7 @@ export function useSubscription(targetId?: string, myId?: string) {
 
       if (!error) {
         setIsSubscribed(true);
-        toast.info('구독을 시작했어요!');
+        toast.info('팔로우를 시작했어요!');
 
         queryClient.setQueryData<Set<string>>(
           ['mySubscriptions', myId],
@@ -91,7 +91,7 @@ export function useSubscription(targetId?: string, myId?: string) {
             Authorization: `Bearer ${session?.access_token ?? ''}`,
           },
           body: JSON.stringify({ target_id: targetId }),
-        }).catch((err) => console.error('구독 알림 에러:', err));
+        }).catch((err) => console.error('팔로우 알림 에러:', err));
       }
     }
   };


### PR DESCRIPTION
### 작업 내용
- `ProfileData` 타입에 `weight: number | null` 필드 추가, profiles 테이블 조회 시 `weight` 컬럼 포함
- `saveFullProfile`에 `weight` 파라미터(optional) 추가, `resetProfile` 시 `weight`는 `null`로 초기화
- toast 안내 문구 및 콘솔 에러 로그 '팔로우'로 통일
