### PR TITLE
feat: 프로필 체중 필드 추가

### DIFF
--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -67,6 +67,7 @@ export default function ProfileCard({
     nickname: string,
     avatar_url: string,
     status_message: string,
+    weight: number | null,
   ) => {
     if (!profile) return;
     const success = await saveFullProfile(
@@ -74,6 +75,7 @@ export default function ProfileCard({
       status_message,
       avatar_url,
       profile.is_public,
+      weight,
     );
 
     if (success) {
@@ -98,6 +100,7 @@ export default function ProfileCard({
         profile.status_message,
         profile.avatar_url,
         nextPublicStatus,
+        profile.weight,
       );
 
       if (success) {
@@ -187,6 +190,7 @@ export default function ProfileCard({
                 initialAvatar={profile.avatar_url}
                 initialStatus={profile.status_message}
                 initialIsPublic={profile.is_public}
+                initialWeight={profile.weight}
                 onUpdate={handleUpdate}
                 onEditingChange={setIsEditing}
               />

--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
@@ -20,7 +20,13 @@ type ProfileEditProps = {
   initialAvatar: string;
   initialStatus: string;
   initialIsPublic: boolean;
-  onUpdate: (nickname: string, avatar: string, status: string) => void;
+  initialWeight: number | null;
+  onUpdate: (
+    nickname: string,
+    avatar: string,
+    status: string,
+    weight: number | null,
+  ) => void;
   onEditingChange: (v: boolean) => void;
 };
 
@@ -30,12 +36,16 @@ export default function ProfileEdit({
   initialAvatar,
   initialStatus,
   initialIsPublic,
+  initialWeight,
   onUpdate,
   onEditingChange,
 }: ProfileEditProps) {
   const [tempNickname, setTempNickname] = useState<string>(initialNickname);
   const [tempStatus, setTempStatus] = useState<string>(initialStatus);
   const [tempAvatar, setTempAvatar] = useState<string>(initialAvatar);
+  const [tempWeight, setTempWeight] = useState<string>(
+    initialWeight != null ? String(initialWeight) : '',
+  );
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const {
@@ -76,15 +86,24 @@ export default function ProfileEdit({
       return;
     }
 
+    const parsedWeight = tempWeight.trim() !== '' ? Number(tempWeight) : null;
+    if (parsedWeight !== null) {
+      if (isNaN(parsedWeight) || parsedWeight < 30 || parsedWeight > 300) {
+        toast.info('체중은 30kg ~ 300kg 사이로 입력해 주세요.');
+        return;
+      }
+    }
+
     ConfirmToast('정말 변경하시겠습니까?', async () => {
       const success = await saveFullProfile(
         trimmedNickname,
         trimmedStatus,
         tempAvatar,
         initialIsPublic,
+        parsedWeight,
       );
       if (success) {
-        onUpdate(trimmedNickname, tempAvatar, trimmedStatus);
+        onUpdate(trimmedNickname, tempAvatar, trimmedStatus, parsedWeight);
         onEditingChange(false);
         toast.success('프로필이 변경되었습니다!');
       }
@@ -95,7 +114,8 @@ export default function ProfileEdit({
     const isChanged =
       tempNickname !== initialNickname ||
       tempStatus !== initialStatus ||
-      tempAvatar !== initialAvatar;
+      tempAvatar !== initialAvatar ||
+      tempWeight !== (initialWeight != null ? String(initialWeight) : '');
 
     if (isChanged) {
       ConfirmToast(
@@ -121,7 +141,8 @@ export default function ProfileEdit({
         setTempNickname(defaultNickname);
         setTempAvatar(defaultAvatar);
         setTempStatus(defaultStatus);
-        onUpdate(defaultNickname, defaultAvatar, defaultStatus);
+        setTempWeight('');
+        onUpdate(defaultNickname, defaultAvatar, defaultStatus, null);
         onEditingChange(false);
         toast.success('프로필이 초기화되었습니다!');
       }
@@ -215,6 +236,21 @@ export default function ProfileEdit({
                 maxLength={10}
               />
               <span>{tempNickname.length}/10</span>
+            </div>
+          </div>
+
+          <div className={styles.field}>
+            <label>체중 (kg)</label>
+            <div className={styles.inputWrapper}>
+              <input
+                type='number'
+                value={tempWeight}
+                onChange={(e) => setTempWeight(e.target.value)}
+                placeholder='체중을 입력해주세요. (선택)'
+                min={30}
+                max={300}
+              />
+              <span>kg</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### 작업 내용
- `initialWeight` prop 추가 및 `tempWeight` 상태 관리
- 체중 입력 UI 추가 (숫자 입력, 30kg ~ 300kg 범위 제한)
- 저장 시 체중 값 유효성 검증 로직 추가
  - 미입력 시 `null` 허용 (선택 항목)
  - 범위(30~300) 벗어나면 토스트 안내 후 저장 중단
- `handleConfirmSave`에서 `saveFullProfile`, `onUpdate` 호출 시 파싱된 체중 값 전달
- `handleCancel`의 변경 여부 감지 로직에 체중 비교 추가
- `handleReset`(프로필 초기화) 시 체중 값도 초기화되도록 처리
- `ProfileEdit`에 `initialWeight={profile.weight}` 전달
- `handleUpdate`에 `weight` 파라미터 추가, `saveFullProfile` 호출 시 전달
- `handleTogglePublic`(공개/비공개 전환) 호출 시에도 기존 `profile.weight` 값을 유지하도록 수정
