### PR TITLE
feat: 체중 대비 밸런스 차트 탭 추가 및 반응형 스타일 개선

### DIFF
--- a/src/components/Charts/Charts.module.scss
+++ b/src/components/Charts/Charts.module.scss
@@ -7,6 +7,12 @@
 .tabGroup {
   display: flex;
   gap: 6px;
+
+  @media (max-width: 768px) {
+    width: 100%;
+    justify-content: flex-start;
+    margin-bottom: 10px;
+  }
 }
 
 .tabBtn {

--- a/src/components/Charts/Charts.tsx
+++ b/src/components/Charts/Charts.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { LineChart, Radar } from 'lucide-react';
+import { LineChart, Radar, Weight } from 'lucide-react';
 
 import RecordChart from './components/RecordChart/RecordChart';
 import StrengthRadarChart from './components/StrengthRadarChart/StrengthRadarChart';
+import BodyweightRadarChart from './components/BodyweightRadarChart/BodyweightRadarChart';
 
 import styles from './Charts.module.scss';
 
@@ -12,11 +13,12 @@ type ChartsProps = {
   userId?: string;
 };
 
-type ChartView = 'record' | 'radar';
+type ChartView = 'record' | 'radar' | 'bodyweight';
 
 const TABS: { key: ChartView; label: string; icon: React.ReactNode }[] = [
   { key: 'record', label: '성장 곡선', icon: <LineChart size={20} /> },
   { key: 'radar', label: '밸런스 분석', icon: <Radar size={20} /> },
+  { key: 'bodyweight', label: '체중 대비', icon: <Weight size={20} /> },
 ];
 
 export default function Charts({ userId }: ChartsProps) {
@@ -39,10 +41,14 @@ export default function Charts({ userId }: ChartsProps) {
 
   return (
     <div className={styles.chartsWrapper}>
-      {activeView === 'record' ? (
+      {activeView === 'record' && (
         <RecordChart userId={userId} tabButtons={tabButtons} />
-      ) : (
+      )}
+      {activeView === 'radar' && (
         <StrengthRadarChart userId={userId} tabButtons={tabButtons} />
+      )}
+      {activeView === 'bodyweight' && (
+        <BodyweightRadarChart userId={userId} tabButtons={tabButtons} />
       )}
     </div>
   );


### PR DESCRIPTION
### 작업 내용
- `Chart.tsx`에 `BodyweightRadarChart` 컴포넌트 추가 및 탭 목록(`TABS`)에 반영
- `ChartView` 타입에 `'bodyweight'` 추가
- 기존 삼항 연산자 렌더링 방식을 조건부 렌더링(`&&`)으로 변경하여 탭 3개 이상도 확장 가능하도록 개선
- `tabGroup`에 768px 이하 모바일 반응형 스타일 추가