### PR TITLE
style: 운동 기록 차트 및 리스트 모바일 헤더 레이아웃 개선

### DIFF
--- a/src/components/Charts/components/RecordChart/RecordChart.module.scss
+++ b/src/components/Charts/components/RecordChart/RecordChart.module.scss
@@ -17,6 +17,12 @@
     align-items: center;
     justify-content: space-between;
     margin-bottom: 20px;
+
+    @media (max-width: 768px) {
+      flex-direction: column-reverse;
+      align-items: flex-start;
+      gap: 8px;
+    }
   }
 
   h1 {
@@ -24,8 +30,8 @@
     color: $text-dark;
     margin-bottom: 0;
 
-    @media (max-width: 400px) {
-      @include font-md-title;
+    @media (max-width: 768px) {
+      margin-left: 6px;
     }
 
     strong {

--- a/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.module.scss
+++ b/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.module.scss
@@ -18,6 +18,12 @@
     align-items: center;
     justify-content: space-between;
     margin-bottom: 4px;
+
+    @media (max-width: 768px) {
+      flex-direction: column-reverse;
+      align-items: flex-start;
+      gap: 8px;
+    }
   }
 
   h1 {
@@ -25,8 +31,8 @@
     color: $text-dark;
     margin-bottom: 0;
 
-    @media (max-width: 400px) {
-      @include font-md-title;
+    @media (max-width: 768px) {
+      margin-left: 6px;
     }
 
     strong {
@@ -44,6 +50,10 @@
       @include font-body;
       color: $text-muted;
       margin-bottom: 0;
+
+      @media (max-width: 768px) {
+        margin-left: 6px;
+      }
 
       @media (max-width: 400px) {
         @include font-sm;

--- a/src/components/RecordList/RecordList.module.scss
+++ b/src/components/RecordList/RecordList.module.scss
@@ -20,8 +20,8 @@
     color: $text-dark;
     margin-bottom: 20px;
 
-    @media (max-width: 400px) {
-      @include font-md-title;
+    @media (max-width: 768px) {
+      margin-left: 6px;
     }
 
     strong {

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -3,6 +3,7 @@
   padding: 0;
   margin: 0;
   -webkit-tap-highlight-color: transparent;
+  user-select: none;
 }
 
 body {


### PR DESCRIPTION
### 작업 내용
- 차트/요약 카드 컴포넌트의 `.header`에 `flex-direction: column-reverse`, `align-items: flex-start`, `gap: 8px` 적용하여 모바일(768px 이하)에서 헤더 내 요소들이 세로로, 역순으로 정렬되도록 변경
- `h1` 제목의 400px 이하 폰트 축소(`font-md-title`) 제거 및 768px 이하에서 `margin-left: 6px` 적용하여 정렬 보정
- 서브타이틀(`.subtitle`)에도 동일하게 768px 이하에서 `margin-left: 6px` 적용
- 전역 셀렉터(`*`)에 `user-select: none` 추가하여 모바일 등에서 불필요한 텍스트 드래그 선택 방지