### PR TITLE
fix: PWA 프리캐싱 오류 해결을 위한 오프라인 페이지 추가

### DIFF
--- a/src/app/~offline/Offline.module.scss
+++ b/src/app/~offline/Offline.module.scss
@@ -1,0 +1,4 @@
+.container {
+  padding: 24px;
+  text-align: center;
+}

--- a/src/app/~offline/page.tsx
+++ b/src/app/~offline/page.tsx
@@ -1,0 +1,10 @@
+import styles from './offline.module.scss';
+
+export default function OfflinePage() {
+  return (
+    <div className={styles.container}>
+      <h1>오프라인 상태예요</h1>
+      <p>인터넷 연결을 확인한 후 다시 시도해주세요.</p>
+    </div>
+  );
+}

--- a/src/app/~offline/page.tsx
+++ b/src/app/~offline/page.tsx
@@ -1,4 +1,4 @@
-import styles from './offline.module.scss';
+import styles from './Offline.module.scss';
 
 export default function OfflinePage() {
   return (


### PR DESCRIPTION
### 작업 내용
- 서비스워커 프리캐싱 대상에 포함되어 있으나 실제로는 존재하지 않던 `/~offline` 경로에 대응하는 페이지 추가
- 해당 경로가 200을 정상 반환하도록 하여 서비스워커 install 오류 해결

### 관련 이슈
- #140 
