### PR TITLE
refactor: 푸시 구독 로직 공통 유틸화 및 재구독 플로우 개선

### DIFF
--- a/src/hooks/useNotificationToggle.ts
+++ b/src/hooks/useNotificationToggle.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
 import { supabase } from '@/lib/supabase';
+import { subscribeAndSave } from '@/utils/pushSubscriptionUtils';
 
 export function useNotificationToggle(userId?: string | null) {
   const [isNotificationOn, setIsNotificationOn] = useState<boolean>(true);
@@ -51,19 +52,31 @@ export function useNotificationToggle(userId?: string | null) {
       .eq('user_id', userId)
       .select('user_id');
 
-    setToggling(false);
-
     if (error) {
+      setToggling(false);
       console.error('알림 상태 변경 실패:', error);
       toast.error('알림 설정을 변경하지 못했어요. 잠시 후 다시 시도해주세요.');
       return;
     }
 
+    // 구독 row가 없는 상태일 때 자동 재구독 시도
     if (!data || data.length === 0) {
-      toast.error('푸시 알림을 먼저 허용해주세요.');
+      const resubscribed = await subscribeAndSave(userId);
+      setToggling(false);
+
+      if (!resubscribed) {
+        toast.error(
+          '알림 권한이 필요해요. 브라우저 설정에서 알림을 허용한 뒤 다시 시도해주세요.',
+        );
+        return;
+      }
+
+      setIsNotificationOn(true);
+      toast.info('전체 알림을 켰어요!');
       return;
     }
 
+    setToggling(false);
     setIsNotificationOn(next);
     toast.info(next ? '전체 알림을 켰어요!' : '전체 알림을 껐어요!');
   };

--- a/src/hooks/usePushNotification.ts
+++ b/src/hooks/usePushNotification.ts
@@ -2,71 +2,11 @@
 
 import { useEffect } from 'react';
 
-import { supabase } from '@/lib/supabase';
-
-const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!;
-
-function urlBase64ToUint8Array(base64String: string) {
-  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
-  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
-  const rawData = atob(base64);
-
-  return Uint8Array.from([...rawData].map((char) => char.charCodeAt(0)));
-}
+import { subscribeAndSave } from '@/utils/pushSubscriptionUtils';
 
 export function usePushNotification(userId: string | null) {
   useEffect(() => {
     if (!userId) return;
-    if (!('serviceWorker' in navigator)) return;
-    if (!('PushManager' in window)) return;
-    if (!VAPID_PUBLIC_KEY) return;
-
-    async function register() {
-      try {
-        const permission = await Notification.requestPermission();
-        if (permission !== 'granted') return;
-
-        const registration =
-          await navigator.serviceWorker.register('/serwist/sw.js');
-
-        await navigator.serviceWorker.ready;
-
-        let subscription = await registration.pushManager.getSubscription();
-
-        if (!subscription) {
-          subscription = await registration.pushManager.subscribe({
-            userVisibleOnly: true,
-            applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
-          });
-        }
-
-        const { data: existing } = await supabase
-          .from('push_subscriptions')
-          .select('id')
-          .eq('user_id', userId)
-          .maybeSingle();
-
-        if (existing) {
-          const { error } = await supabase
-            .from('push_subscriptions')
-            .update({ subscription: subscription.toJSON() })
-            .eq('user_id', userId);
-
-          if (error) throw error;
-        } else {
-          const { error } = await supabase.from('push_subscriptions').insert({
-            user_id: userId,
-            subscription: subscription.toJSON(),
-            is_active: true,
-          });
-
-          if (error) throw error;
-        }
-      } catch (error) {
-        console.error('[Push] 에러 발생 원인:', error);
-      }
-    }
-
-    register();
+    subscribeAndSave(userId);
   }, [userId]);
 }

--- a/src/utils/pushSubscriptionUtils.ts
+++ b/src/utils/pushSubscriptionUtils.ts
@@ -1,0 +1,67 @@
+import { supabase } from '@/lib/supabase';
+
+const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!;
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+
+  return Uint8Array.from([...rawData].map((char) => char.charCodeAt(0)));
+}
+
+/**
+ * 서비스워커 등록 + 푸시 구독 + DB 저장까지 한 번에 처리하는 함수
+ * 성공하면 true, 실패(권한 거부 포함)하면 false 반환.
+ */
+export async function subscribeAndSave(userId: string): Promise<boolean> {
+  if (!('serviceWorker' in navigator)) return false;
+  if (!('PushManager' in window)) return false;
+  if (!VAPID_PUBLIC_KEY) return false;
+
+  try {
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') return false;
+
+    const registration =
+      await navigator.serviceWorker.register('/serwist/sw.js');
+    await navigator.serviceWorker.ready;
+
+    let subscription = await registration.pushManager.getSubscription();
+
+    if (!subscription) {
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
+      });
+    }
+
+    const { data: existing } = await supabase
+      .from('push_subscriptions')
+      .select('id')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (existing) {
+      const { error } = await supabase
+        .from('push_subscriptions')
+        .update({ subscription: subscription.toJSON(), is_active: true })
+        .eq('user_id', userId);
+
+      if (error) throw error;
+    } else {
+      const { error } = await supabase.from('push_subscriptions').insert({
+        user_id: userId,
+        subscription: subscription.toJSON(),
+        is_active: true,
+      });
+
+      if (error) throw error;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('[Push] 구독 저장 실패:', error);
+    return false;
+  }
+}


### PR DESCRIPTION
### 작업 내용
`pushSubscriptionUtils.ts` 
- 서비스워커 등록 + 푸시 구독 + DB 저장(insert/update)을 한 번에 처리하는 `subscribeAndSave` 함수 추가
- 성공 시 `true`, 실패(권한 거부 포함) 시 `false` 반환하도록 설계해 호출부에서 결과에 따른 분기 처리 가능

`usePushNotification.ts`
- 훅 내부에 중복 작성되어 있던 서비스워커 등록/구독/DB 저장 로직 제거
- `subscribeAndSave` 유틸 함수 호출로 대체

`useNotificationToggle.ts`
- 알림 토글 시 `push_subscriptions` row가 없는 경우 기존에는 에러 토스트만 노출했으나 `subscribeAndSave`를 호출해 자동 재구독을 시도하도록 변경
- 재구독 성공 시 알림 ON 상태로 반영 및 안내 토스트 노출
- 재구독 실패 시에만 브라우저 알림 권한 허용 안내 토스트 노출

### 관련 이슈 
- #141 