### PR TITLE
fix: 알림 토글 예외 처리 및 서비스워커 등록 스코프 개선

### DIFF
--- a/src/hooks/useNotificationToggle.ts
+++ b/src/hooks/useNotificationToggle.ts
@@ -46,39 +46,43 @@ export function useNotificationToggle(userId?: string | null) {
     const next = !isNotificationOn;
     setToggling(true);
 
-    const { data, error } = await supabase
-      .from('push_subscriptions')
-      .update({ is_active: next })
-      .eq('user_id', userId)
-      .select('user_id');
+    try {
+      const { data, error } = await supabase
+        .from('push_subscriptions')
+        .update({ is_active: next })
+        .eq('user_id', userId)
+        .select('user_id');
 
-    if (error) {
-      setToggling(false);
-      console.error('알림 상태 변경 실패:', error);
-      toast.error('알림 설정을 변경하지 못했어요. 잠시 후 다시 시도해주세요.');
-      return;
-    }
-
-    // 구독 row가 없는 상태일 때 자동 재구독 시도
-    if (!data || data.length === 0) {
-      const resubscribed = await subscribeAndSave(userId);
-      setToggling(false);
-
-      if (!resubscribed) {
+      if (error) {
         toast.error(
-          '알림 권한이 필요해요. 브라우저 설정에서 알림을 허용한 뒤 다시 시도해주세요.',
+          '알림 설정을 변경할 수 없어요. 잠시 후 다시 시도해 주세요.',
         );
         return;
       }
 
-      setIsNotificationOn(true);
-      toast.info('전체 알림을 켰어요!');
-      return;
-    }
+      if (!data || data.length === 0) {
+        const resubscribed = await subscribeAndSave(userId);
 
-    setToggling(false);
-    setIsNotificationOn(next);
-    toast.info(next ? '전체 알림을 켰어요!' : '전체 알림을 껐어요!');
+        if (!resubscribed) {
+          toast.error(
+            '알림 권한이 필요해요. 브라우저 설정에서 알림을 허용한 뒤 다시 시도해 주세요.',
+          );
+          return;
+        }
+
+        setIsNotificationOn(true);
+        toast.info('전체 알림을 켰어요!');
+        return;
+      }
+
+      setIsNotificationOn(next);
+      toast.info(next ? '전체 알림을 켰어요!' : '전체 알림을 껐어요!');
+    } catch (e) {
+      console.error('알림 토글 처리 중 예외 발생:', e);
+      toast.error('알 수 없는 오류가 발생했어요.');
+    } finally {
+      setToggling(false);
+    }
   };
 
   return { isNotificationOn, loading, toggling, toggle };

--- a/src/utils/pushSubscriptionUtils.ts
+++ b/src/utils/pushSubscriptionUtils.ts
@@ -23,8 +23,13 @@ export async function subscribeAndSave(userId: string): Promise<boolean> {
     const permission = await Notification.requestPermission();
     if (permission !== 'granted') return false;
 
-    const registration =
-      await navigator.serviceWorker.register('/serwist/sw.js');
+    const registration = await navigator.serviceWorker.register(
+      '/serwist/sw.js',
+      {
+        scope: '/',
+      },
+    );
+
     await navigator.serviceWorker.ready;
 
     let subscription = await registration.pushManager.getSubscription();


### PR DESCRIPTION
### 작업 내용
`useNotificationToggle` 예외 처리 개선
- `toggle` 함수에 try/catch/finally 추가
- 기존에는 update 요청 중 예상치 못한 예외(네트워크 오류 등)가 발생하면
  `setToggling(false)`가 호출되지 않아 토글 버튼이 로딩 상태로 멈추는 문제가 있었음
- finally 블록에서 `setToggling(false)`를 처리하도록 정리하여
  성공/실패/예외 모든 케이스에서 상태가 정상적으로 복구되도록 수정
- 예외 발생 시 사용자에게 오류 토스트를 노출하도록 추가

`subscribeAndSave` 서비스워커 등록 시 scope 명시
- `navigator.serviceWorker.register` 호출 시 `scope: '/'` 옵션을 명시적으로 지정
- 서비스워커 적용 범위를 루트 경로로 명확히 하여 등록 스코프 관련 이슈 방지

### 관련 이슈 
- #145