### PR TITLE
fix: 대시보드 차트 레이아웃 오버플로우 및 안내 문구 개선

### DIFF
--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -8,7 +8,7 @@
 
 .dashboardGrid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
   gap: 20px;
   width: 100%;
   margin-bottom: 20px;

--- a/src/components/Charts/components/BodyweightRadarChart/BodyweightRadarChart.module.scss
+++ b/src/components/Charts/components/BodyweightRadarChart/BodyweightRadarChart.module.scss
@@ -8,6 +8,7 @@
   padding: 20px;
   width: 100%;
   overflow: hidden;
+  min-width: 0;
 
   @media (max-width: 768px) {
     padding: 20px 10px;

--- a/src/components/Charts/components/BodyweightRadarChart/BodyweightRadarChart.tsx
+++ b/src/components/Charts/components/BodyweightRadarChart/BodyweightRadarChart.tsx
@@ -236,7 +236,7 @@ export default function BodyweightRadarChart({
             subMessage={
               isReadOnly
                 ? `${displayName}님이 아직 체중을 등록하지 않았어요.`
-                : '프로필 편집에서 체중을 입력하면 체중 대비 밸런스를 확인할 수 있어요!'
+                : '프로필 수정에서 체중을 입력하면 체중 대비 밸런스를 확인할 수 있어요!'
             }
           />
         ) : !hasEnoughData ? (
@@ -312,7 +312,7 @@ export default function BodyweightRadarChart({
                       fill={
                         entry.score >= 100
                           ? COLORS[entry.subject as keyof typeof COLORS]
-                          : `${COLORS[entry.subject as keyof typeof COLORS]}66` // 목표 미달 시 반투명
+                          : `${COLORS[entry.subject as keyof typeof COLORS]}66`
                       }
                     />
                   ))}

--- a/src/components/Charts/components/RecordChart/RecordChart.module.scss
+++ b/src/components/Charts/components/RecordChart/RecordChart.module.scss
@@ -1,12 +1,13 @@
 @use '../../../../styles' as *;
 
-.chartContainer {
+.container {
   background: $white;
   box-shadow: $shadow-md;
   border: 1px solid $border-soft;
   border-radius: $radius-main;
   padding: 20px;
   width: 100%;
+  min-width: 0;
 
   @media (max-width: 768px) {
     padding: 20px 10px;

--- a/src/components/Charts/components/RecordChart/RecordChart.tsx
+++ b/src/components/Charts/components/RecordChart/RecordChart.tsx
@@ -257,7 +257,7 @@ export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
   };
 
   return (
-    <div className={styles.chartContainer}>
+    <div className={styles.container}>
       <div className={styles.header}>
         <h1>
           {displayName && (
@@ -342,7 +342,7 @@ export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
             message={
               isReadOnly
                 ? `${displayName}님의 차트 데이터가 부족합니다.`
-                : '차트를 그리려면 최소 2개 이상의 기록이 필요합니다.'
+                : '최소 2개 이상의 기록이 필요합니다.'
             }
             subMessage={
               !isReadOnly

--- a/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.module.scss
+++ b/src/components/Charts/components/StrengthRadarChart/StrengthRadarChart.module.scss
@@ -8,6 +8,7 @@
   padding: 20px;
   width: 100%;
   overflow: hidden;
+  min-width: 0;
 
   @media (max-width: 768px) {
     padding: 20px 10px;

--- a/src/components/shared/Empty/Empty.module.scss
+++ b/src/components/shared/Empty/Empty.module.scss
@@ -7,7 +7,8 @@
   background-color: transparent;
   border-radius: 16px;
   padding: 30px;
-  white-space: nowrap;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 
   p {
     @include font-md-title;


### PR DESCRIPTION
### 작업 내용
대시보드 그리드 레이아웃 오버플로우 수정
- `.dashboardGrid`의 `grid-template-columns`을 `1fr` → `minmax(0, 1fr)`로 변경
- grid item의 기본 `min-width: auto`로 인해 내부 차트 콘텐츠가 넘칠 때 그리드 트랙이 늘어나던 문제 해결

`BodyweightRadarChart` 레이아웃 오버플로우 수정
- `.container`에 `min-width: 0` 추가
- flex 컨테이너 내부에서 차트(recharts) 콘텐츠로 인해 너비가 축소되지 않던 문제 해결

`Empty` 텍스트 줄바꿈 개선
- `white-space: nowrap` → `word-break: keep-all; overflow-wrap: break-word;`
- 좁은 화면에서 안내 문구가 잘리거나 넘치던 문제 해결 및 단어 단위 자연스러운 줄바꿈 적용

`BodyweightRadarChart` 체중 미입력 안내 문구 수정

- "프로필 편집에서 체중을 입력하면..." → "프로필 수정에서 체중을 입력하면..."

`RecordChart` 기록 부족 안내 문구 간소화

- "차트를 그리려면 최소 2개 이상의 기록이 필요합니다." → "최소 2개 이상의 기록이 필요합니다."