### PR TITLE
feat: 멤버 목록 카드 인터랙션 개선 및 애니메이션 추가

### DIFF
--- a/src/app/members/components/UserCard/UserCard.module.scss
+++ b/src/app/members/components/UserCard/UserCard.module.scss
@@ -11,10 +11,23 @@
   transition: $transition-base;
   position: relative;
 
-  &:hover {
-    transform: $lift-sm;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  touch-action: manipulation;
+
+  @media (hover: hover) {
+    &:hover:not(.privateCard) {
+      transform: $lift-sm;
+      border-color: $blue;
+      box-shadow: 0 4px 12px rgba(0, 123, 255, 0.2);
+    }
+  }
+
+  &:active:not(.privateCard):not(:has(.subscribedBadgeBtn:active)) {
+    transform: scale(0.98);
     border-color: $blue;
-    box-shadow: 0 4px 12px rgba(0, 123, 255, 0.2);
+    box-shadow: 0 2px 6px rgba(0, 123, 255, 0.15);
   }
 }
 
@@ -80,7 +93,9 @@
       transition: $transition-base;
 
       &:hover {
-        background: rgba($blue, 0.1);
+        .subscribedBadge {
+          @include wiggle-anim(0.25s);
+        }
       }
     }
 
@@ -88,6 +103,7 @@
       flex-shrink: 0;
       color: $blue;
       pointer-events: none;
+      transition: transform 0.2s ease-in-out;
     }
   }
 
@@ -129,5 +145,9 @@
     color: $white;
     padding: 2px 6px;
     border-radius: 4px;
+  }
+
+  .subscribedBadgeBtn {
+    pointer-events: auto;
   }
 }

--- a/src/styles/mixins/_animations.scss
+++ b/src/styles/mixins/_animations.scss
@@ -25,3 +25,20 @@
 @mixin fade-in-anim($duration: 0.3s) {
   animation: fadeIn $duration ease forwards;
 }
+
+@keyframes wiggle {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(-8deg);
+  }
+  75% {
+    transform: rotate(8deg);
+  }
+}
+
+@mixin wiggle-anim($duration: 0.25s) {
+  animation: wiggle $duration ease-in-out infinite alternate;
+}


### PR DESCRIPTION
### 작업 내용
wiggle 애니메이션 mixin 추가
- `@keyframes wiggle` 정의 (좌우 회전 흔들림 효과)
- `wiggle-anim` mixin 추가 (기본 duration: 0.25s, ease-in-out, alternate)

`UserCard` 터치 인터랙션 개선
- 텍스트 선택/롱프레스 콜아웃 방지 처리 (`user-select`, `touch-callout`, `touch-action`)
- `@media (hover: hover)` 적용으로 hover 가능한 기기에서만 hover 스타일 동작하도록 개선
- `:active` 시 눌림 효과(scale, border, shadow) 추가
  - `privateCard`이거나 구독 뱃지 버튼 클릭 시에는 제외
- `subscribedBadge`에 hover 시 wiggle 애니메이션 적용
- `privateCard` 내부의 `subscribedBadgeBtn`은 `pointer-events: auto`로 예외 처리하여 클릭 가능하도록 유지