### PR TITLE
feat: 프로필에 성별 필드 추가

### DIFF
--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -4,16 +4,14 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import styles from './Profile.module.scss';
-
 import CharacterView from './components/CharacterView/CharacterView';
 import ProfileEdit from './components/ProfileEdit/ProfileEdit';
 import ProfileInfo from './components/ProfileInfo/ProfileInfo';
 import StatsSection from './components/StatsSection/StatsSection';
 import ActionsSection from './components/ActionsSection/ActionsSection';
 
-import Loading from '../shared/Loading/Loading';
-import Empty from '../shared/Empty/Empty';
+import Loading from '@/components/shared/Loading/Loading';
+import Empty from '@/components/shared/Empty/Empty';
 import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
 
 import { useAuth } from '@/hooks/useAuth';
@@ -24,6 +22,8 @@ import { useSubscription } from '@/hooks/useSubscription';
 import { useNotificationToggle } from '@/hooks/useNotificationToggle';
 
 import { calculateTotalPR } from '@/utils/recordUtils';
+
+import styles from './Profile.module.scss';
 
 type ProfileCardProps = {
   userId?: string;
@@ -68,6 +68,7 @@ export default function ProfileCard({
     avatar_url: string,
     status_message: string,
     weight: number | null,
+    gender: 'male' | 'female' | null,
   ) => {
     if (!profile) return;
     const success = await saveFullProfile(
@@ -76,6 +77,7 @@ export default function ProfileCard({
       avatar_url,
       profile.is_public,
       weight,
+      gender,
     );
 
     if (success) {
@@ -101,6 +103,7 @@ export default function ProfileCard({
         profile.avatar_url,
         nextPublicStatus,
         profile.weight,
+        profile.gender,
       );
 
       if (success) {
@@ -191,6 +194,7 @@ export default function ProfileCard({
                 initialStatus={profile.status_message}
                 initialIsPublic={profile.is_public}
                 initialWeight={profile.weight}
+                initialGender={profile.gender}
                 onUpdate={handleUpdate}
                 onEditingChange={setIsEditing}
               />

--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.module.scss
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.module.scss
@@ -122,6 +122,33 @@
           }
         }
       }
+
+      .genderToggle {
+        display: flex;
+        gap: 8px;
+
+        .genderBtn {
+          @include font-body;
+          flex: 1;
+          padding: 10px 0;
+          border: 1.5px solid $border-soft;
+          border-radius: $radius-main;
+          background: $off-white;
+          color: $text-muted;
+          cursor: pointer;
+          transition:
+            border-color 0.2s,
+            background 0.2s,
+            color 0.2s;
+
+          &.active {
+            border-color: $blue;
+            background: rgba($blue, 0.07);
+            color: $blue;
+            font-weight: 600;
+          }
+        }
+      }
     }
   }
 

--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
@@ -6,13 +6,13 @@ import { User } from '@supabase/supabase-js';
 import { Camera } from 'lucide-react';
 import { toast } from 'sonner';
 
-import styles from './ProfileEdit.module.scss';
-
 import Button from '@/components/shared/Button/Button';
 import Loading from '@/components/shared/Loading/Loading';
 import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
 
 import { useProfileUpdate } from '@/hooks/useProfileUpdate';
+
+import styles from './ProfileEdit.module.scss';
 
 type ProfileEditProps = {
   user: User;
@@ -21,11 +21,13 @@ type ProfileEditProps = {
   initialStatus: string;
   initialIsPublic: boolean;
   initialWeight: number | null;
+  initialGender: 'male' | 'female' | null;
   onUpdate: (
     nickname: string,
     avatar: string,
     status: string,
     weight: number | null,
+    gender: 'male' | 'female' | null,
   ) => void;
   onEditingChange: (v: boolean) => void;
 };
@@ -37,6 +39,7 @@ export default function ProfileEdit({
   initialStatus,
   initialIsPublic,
   initialWeight,
+  initialGender,
   onUpdate,
   onEditingChange,
 }: ProfileEditProps) {
@@ -45,6 +48,9 @@ export default function ProfileEdit({
   const [tempAvatar, setTempAvatar] = useState<string>(initialAvatar);
   const [tempWeight, setTempWeight] = useState<string>(
     initialWeight != null ? String(initialWeight) : '',
+  );
+  const [tempGender, setTempGender] = useState<'male' | 'female' | null>(
+    initialGender,
   );
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -101,9 +107,16 @@ export default function ProfileEdit({
         tempAvatar,
         initialIsPublic,
         parsedWeight,
+        tempGender,
       );
       if (success) {
-        onUpdate(trimmedNickname, tempAvatar, trimmedStatus, parsedWeight);
+        onUpdate(
+          trimmedNickname,
+          tempAvatar,
+          trimmedStatus,
+          parsedWeight,
+          tempGender,
+        );
         onEditingChange(false);
         toast.success('프로필이 변경되었습니다!');
       }
@@ -115,7 +128,8 @@ export default function ProfileEdit({
       tempNickname !== initialNickname ||
       tempStatus !== initialStatus ||
       tempAvatar !== initialAvatar ||
-      tempWeight !== (initialWeight != null ? String(initialWeight) : '');
+      tempWeight !== (initialWeight != null ? String(initialWeight) : '') ||
+      tempGender !== initialGender;
 
     if (isChanged) {
       ConfirmToast(
@@ -142,7 +156,8 @@ export default function ProfileEdit({
         setTempAvatar(defaultAvatar);
         setTempStatus(defaultStatus);
         setTempWeight('');
-        onUpdate(defaultNickname, defaultAvatar, defaultStatus, null);
+        setTempGender(null);
+        onUpdate(defaultNickname, defaultAvatar, defaultStatus, null, null);
         onEditingChange(false);
         toast.success('프로필이 초기화되었습니다!');
       }
@@ -251,6 +266,26 @@ export default function ProfileEdit({
                 max={300}
               />
               <span>kg</span>
+            </div>
+          </div>
+
+          <div className={styles.field}>
+            <label>성별</label>
+            <div className={styles.genderToggle}>
+              <button
+                type='button'
+                className={`${styles.genderBtn} ${tempGender === 'male' ? styles.active : ''}`}
+                onClick={() => setTempGender('male')}
+              >
+                남성
+              </button>
+              <button
+                type='button'
+                className={`${styles.genderBtn} ${tempGender === 'female' ? styles.active : ''}`}
+                onClick={() => setTempGender('female')}
+              >
+                여성
+              </button>
             </div>
           </div>
         </div>

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -8,6 +8,7 @@ export type ProfileData = {
   status_message: string;
   is_public: boolean;
   weight: number | null;
+  gender: 'male' | 'female' | null;
 };
 
 export function useProfile(userId: string | undefined) {
@@ -18,7 +19,9 @@ export function useProfile(userId: string | undefined) {
 
       const { data, error } = await supabase
         .from('profiles')
-        .select('nickname, avatar_url, status_message, is_public, weight')
+        .select(
+          'nickname, avatar_url, status_message, is_public, weight, gender',
+        )
         .eq('id', userId)
         .single();
 
@@ -33,6 +36,7 @@ export function useProfile(userId: string | undefined) {
         status_message: data.status_message || '울끈불끈!',
         is_public: data.is_public ?? true,
         weight: data.weight ?? null,
+        gender: data.gender ?? null,
       };
     },
     enabled: !!userId,

--- a/src/hooks/useProfileUpdate.ts
+++ b/src/hooks/useProfileUpdate.ts
@@ -56,6 +56,7 @@ export function useProfileUpdate(user: User) {
     avatarUrl: string,
     isPublic: boolean,
     weight?: number | null,
+    gender?: 'male' | 'female' | null,
   ) => {
     try {
       const { error } = await supabase.from('profiles').upsert({
@@ -65,6 +66,7 @@ export function useProfileUpdate(user: User) {
         avatar_url: avatarUrl,
         is_public: isPublic,
         weight: weight ?? null,
+        gender: gender ?? null,
         updated_at: new Date().toISOString(),
       });
 
@@ -90,6 +92,7 @@ export function useProfileUpdate(user: User) {
         avatar_url: originalAvatar,
         is_public: true,
         weight: null,
+        gender: null,
         updated_at: new Date().toISOString(),
       });
 


### PR DESCRIPTION
### 작업 내용
`useProfile.ts`
- `ProfileData` 타입에 `gender: 'male' | 'female' | null` 필드 추가
- Supabase 조회 쿼리에 `gender` 컬럼 포함

`useProfileUpdate.ts`
- `saveFullProfile`에 `gender` 파라미터 추가 및 upsert 데이터에 반영
- `resetProfile` 시 `gender`를 `null`로 초기화

`ProfileEdit.tsx`
- `initialGender` prop 및 `tempGender` 상태 추가
- 저장/취소/초기화 로직에 성별 값 반영
- 성별 선택용 남성/여성 토글 버튼 UI 추가

`ProfileEdit.module.scss`
- 성별 토글 버튼(`.genderToggle`, `.genderBtn`) 스타일 및 active 상태 스타일 추가

`ProfileCard.tsx`
- `handleUpdate`, `handleTogglePublic`에서 `gender` 값을 `saveFullProfile`에 전달
- `ProfileEdit`에 `initialGender` prop 전달
- import 경로 절대경로 통일 및 순서 정리
