### PR TITLE
feat: 프로필에 생년월일 필드 추가

### DIFF
--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -69,6 +69,7 @@ export default function ProfileCard({
     status_message: string,
     weight: number | null,
     gender: 'male' | 'female' | null,
+    birthDate: string | null,
   ) => {
     if (!profile) return;
     const success = await saveFullProfile(
@@ -78,6 +79,7 @@ export default function ProfileCard({
       profile.is_public,
       weight,
       gender,
+      birthDate,
     );
 
     if (success) {
@@ -104,6 +106,7 @@ export default function ProfileCard({
         nextPublicStatus,
         profile.weight,
         profile.gender,
+        profile.birth_date,
       );
 
       if (success) {
@@ -195,6 +198,7 @@ export default function ProfileCard({
                 initialIsPublic={profile.is_public}
                 initialWeight={profile.weight}
                 initialGender={profile.gender}
+                initialBirthDate={profile.birth_date}
                 onUpdate={handleUpdate}
                 onEditingChange={setIsEditing}
               />

--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
@@ -22,12 +22,14 @@ type ProfileEditProps = {
   initialIsPublic: boolean;
   initialWeight: number | null;
   initialGender: 'male' | 'female' | null;
+  initialBirthDate: string | null;
   onUpdate: (
     nickname: string,
     avatar: string,
     status: string,
     weight: number | null,
     gender: 'male' | 'female' | null,
+    birthDate: string | null,
   ) => void;
   onEditingChange: (v: boolean) => void;
 };
@@ -40,6 +42,7 @@ export default function ProfileEdit({
   initialIsPublic,
   initialWeight,
   initialGender,
+  initialBirthDate,
   onUpdate,
   onEditingChange,
 }: ProfileEditProps) {
@@ -51,6 +54,9 @@ export default function ProfileEdit({
   );
   const [tempGender, setTempGender] = useState<'male' | 'female' | null>(
     initialGender,
+  );
+  const [tempBirthDate, setTempBirthDate] = useState<string>(
+    initialBirthDate ?? '',
   );
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -100,6 +106,21 @@ export default function ProfileEdit({
       }
     }
 
+    const trimmedBirthDate = tempBirthDate.trim();
+    if (trimmedBirthDate) {
+      const birth = new Date(trimmedBirthDate);
+      const today = new Date();
+      if (isNaN(birth.getTime()) || birth > today) {
+        toast.info('생년월일을 올바르게 입력해 주세요.');
+        return;
+      }
+      const age = today.getFullYear() - birth.getFullYear();
+      if (age > 120 || age < 10) {
+        toast.info('생년월일을 다시 확인해 주세요.');
+        return;
+      }
+    }
+
     ConfirmToast('정말 변경하시겠습니까?', async () => {
       const success = await saveFullProfile(
         trimmedNickname,
@@ -108,6 +129,7 @@ export default function ProfileEdit({
         initialIsPublic,
         parsedWeight,
         tempGender,
+        trimmedBirthDate || null,
       );
       if (success) {
         onUpdate(
@@ -116,6 +138,7 @@ export default function ProfileEdit({
           trimmedStatus,
           parsedWeight,
           tempGender,
+          trimmedBirthDate || null,
         );
         onEditingChange(false);
         toast.success('프로필이 변경되었습니다!');
@@ -129,7 +152,8 @@ export default function ProfileEdit({
       tempStatus !== initialStatus ||
       tempAvatar !== initialAvatar ||
       tempWeight !== (initialWeight != null ? String(initialWeight) : '') ||
-      tempGender !== initialGender;
+      tempGender !== initialGender ||
+      tempBirthDate !== (initialBirthDate ?? '');
 
     if (isChanged) {
       ConfirmToast(
@@ -157,7 +181,15 @@ export default function ProfileEdit({
         setTempStatus(defaultStatus);
         setTempWeight('');
         setTempGender(null);
-        onUpdate(defaultNickname, defaultAvatar, defaultStatus, null, null);
+        setTempBirthDate('');
+        onUpdate(
+          defaultNickname,
+          defaultAvatar,
+          defaultStatus,
+          null,
+          null,
+          null,
+        );
         onEditingChange(false);
         toast.success('프로필이 초기화되었습니다!');
       }
@@ -286,6 +318,18 @@ export default function ProfileEdit({
               >
                 여성
               </button>
+            </div>
+          </div>
+
+          <div className={styles.field}>
+            <label>생년월일</label>
+            <div className={styles.inputWrapper}>
+              <input
+                type='date'
+                value={tempBirthDate}
+                onChange={(e) => setTempBirthDate(e.target.value)}
+                max={new Date().toISOString().split('T')[0]}
+              />
             </div>
           </div>
         </div>

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -9,6 +9,7 @@ export type ProfileData = {
   is_public: boolean;
   weight: number | null;
   gender: 'male' | 'female' | null;
+  birth_date: string | null;
 };
 
 export function useProfile(userId: string | undefined) {
@@ -20,7 +21,7 @@ export function useProfile(userId: string | undefined) {
       const { data, error } = await supabase
         .from('profiles')
         .select(
-          'nickname, avatar_url, status_message, is_public, weight, gender',
+          'nickname, avatar_url, status_message, is_public, weight, gender, birth_date',
         )
         .eq('id', userId)
         .single();
@@ -37,6 +38,7 @@ export function useProfile(userId: string | undefined) {
         is_public: data.is_public ?? true,
         weight: data.weight ?? null,
         gender: data.gender ?? null,
+        birth_date: data.birth_date ?? null,
       };
     },
     enabled: !!userId,

--- a/src/hooks/useProfileUpdate.ts
+++ b/src/hooks/useProfileUpdate.ts
@@ -57,6 +57,7 @@ export function useProfileUpdate(user: User) {
     isPublic: boolean,
     weight?: number | null,
     gender?: 'male' | 'female' | null,
+    birthDate?: string | null,
   ) => {
     try {
       const { error } = await supabase.from('profiles').upsert({
@@ -67,6 +68,7 @@ export function useProfileUpdate(user: User) {
         is_public: isPublic,
         weight: weight ?? null,
         gender: gender ?? null,
+        birth_date: birthDate ?? null,
         updated_at: new Date().toISOString(),
       });
 
@@ -93,6 +95,7 @@ export function useProfileUpdate(user: User) {
         is_public: true,
         weight: null,
         gender: null,
+        birth_date: null,
         updated_at: new Date().toISOString(),
       });
 


### PR DESCRIPTION
### 작업 내용
`useProfile.ts`
  - `ProfileData` 타입에 `birth_date` 필드 추가
  - Supabase 조회 쿼리에 `birth_date` 컬럼 포함

`useProfileUpdate.ts`
  - `saveFullProfile`에 `birthDate` 파라미터 추가 및 upsert 데이터에 반영
  - `resetProfile` 시 `birth_date`를 `null`로 초기화

`ProfileEdit.tsx`
  - 생년월일 입력용 date input UI 추가
  - 저장 시 생년월일 유효성 검사 추가 (형식, 미래 날짜 불가, 나이 범위 10~120세)
  - 취소 시 변경 여부 판단(`isChanged`) 로직에 생년월일 비교 추가
  - 초기화 시 생년월일 값도 함께 리셋

`ProfileCard.tsx`
  - `handleUpdate` 콜백에 `birthDate` 파라미터 추가 및 `saveFullProfile` 호출 시 반영
  - 공개/비공개 토글(`handleTogglePublic`) 시 기존 `birth_date` 값을 유지하도록 반영
  - `ProfileEdit`에 `initialBirthDate` prop 전달
