### PR TITLE
feat: Epley 공식 기반 1RM 계산 및 만 나이 계산 유틸 함수 추가

### DIFF
--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,7 +1,6 @@
 /**
  * 한국 시간 기준 YY. MM. DD 형식 포맷팅 함수
  */
-
 export const formatDate = (dateString: string | Date) => {
   if (!dateString) return '-';
 
@@ -20,7 +19,6 @@ export const formatDate = (dateString: string | Date) => {
 /**
  * 날짜 객체나 문자열을 HTML input 태그에 적합한 'YYYY-MM-DD' 형식으로 변환 함수
  */
-
 export const toInputDate = (dateString: string | Date) => {
   if (!dateString) return '';
   const d = new Date(dateString);
@@ -28,4 +26,32 @@ export const toInputDate = (dateString: string | Date) => {
   const month = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+};
+
+/**
+ * 만 나이 계산 (YYYY-MM-DD 포맷)
+ * Date 타임존 이슈 방지를 위해 문자열 직접 분할 파싱
+ */
+export const calculateAge = (birthDate: string): number => {
+  if (!birthDate) return 0;
+
+  const [year, month, day] = birthDate.split(/[-/.]/).map(Number);
+
+  if (!year || !month || !day) return 0;
+
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth() + 1;
+  const currentDay = today.getDate();
+
+  let age = currentYear - year;
+
+  const isBeforeBirthday =
+    currentMonth < month || (currentMonth === month && currentDay < day);
+
+  if (isBeforeBirthday) {
+    age--;
+  }
+
+  return Math.max(0, age);
 };

--- a/src/utils/recordUtils.ts
+++ b/src/utils/recordUtils.ts
@@ -1,6 +1,16 @@
 import { StrengthRecord } from '@/types/record';
 import { UserSummary } from '@/types/user';
 
+// StrengthRecord 중 'number' 타입을 가진 키만 추출
+type RecordNumberKey = {
+  [K in keyof StrengthRecord]: StrengthRecord[K] extends
+    | number
+    | null
+    | undefined
+    ? K
+    : never;
+}[keyof StrengthRecord];
+
 /**
  * 특정 날짜의 ISO 8601 기준 연도-주차 정보 반환
  */
@@ -42,7 +52,7 @@ const getPrivacyGuard = (isPublic: boolean | undefined): string | null => {
 };
 
 /**
- * 특정 종목의 역대 최고 기록 및 해당 날짜 추출
+ * 특정 종목의 역대 최고 기록(원본 무게 그대로) 및 해당 날짜 추출
  */
 export const getBestRecord = (
   records: StrengthRecord[],
@@ -152,4 +162,38 @@ export const getCombinedTotalFromUser = (user: UserSummary): string => {
   if (total > 0) return `${total}kg`;
   if (user.max_total) return `${user.max_total}kg`;
   return '기록 없음';
+};
+
+/**
+ * 1RM 계산 (Epley 공식)
+ * 고반복(12회 초과)은 근지구력의 영역이므로 1RM 추정 오차가 커집니다. (최대 15회로 제한 권장)
+ */
+export const calc1RM = (weight: number, reps: number): number => {
+  if (weight <= 0 || reps <= 0) return 0;
+  if (reps === 1) return weight;
+
+  const effectiveReps = Math.min(reps, 15);
+  return Math.round(weight * (1 + effectiveReps / 30));
+};
+
+/**
+ * 기록 목록 중 최고 1RM을 탐색 (반복 횟수까지 반영)
+ */
+export const getBest1RM = (
+  records: StrengthRecord[],
+  weightKey: RecordNumberKey,
+  repsKey: RecordNumberKey,
+): number => {
+  if (!records || records.length === 0) return 0;
+
+  return records.reduce((best, record) => {
+    const rawWeight = record[weightKey];
+    const rawReps = record[repsKey];
+
+    const weight = typeof rawWeight === 'number' ? rawWeight : 0;
+    const reps = typeof rawReps === 'number' ? rawReps : 1;
+    const current1RM = calc1RM(weight, reps);
+
+    return current1RM > best ? current1RM : best;
+  }, 0);
 };


### PR DESCRIPTION
### 작업 내용
**1RM 계산 (Epley 공식)**
- `calc1RM`: 중량과 반복 횟수로 예상 1RM 계산
  - 고반복(12회 초과) 시 오차 완화를 위해 반복 수 최대 15회로 제한
- `getBest1RM`: 기록 목록에서 반복 횟수까지 반영한 최고 1RM 탐색
- `RecordNumberKey`: StrengthRecord에서 number 타입 키만 추출하는 유틸 타입 추가

**만 나이 계산**
- `calculateAge`: 생년월일(YYYY-MM-DD 등) 문자열로 만 나이 계산
  - Date 객체의 타임존 이슈를 피하기 위해 문자열 직접 파싱 방식 사용
  - 생일 전이면 나이에서 1 차감 처리