### PR TITLE
fix: 차트 컴포넌트 반응형 레이아웃 개선 및 탭 전환 시 상태 유지

### DIFF
--- a/src/components/Charts/Charts.module.scss
+++ b/src/components/Charts/Charts.module.scss
@@ -1,7 +1,18 @@
 @use '../../styles' as *;
 
+$chart-height: 610px;
+$chart-height-mobile: 650px;
+
 .chartsWrapper {
   width: 100%;
+}
+
+.chartPane {
+  height: $chart-height;
+
+  @media (max-width: 768px) {
+    height: $chart-height-mobile;
+  }
 }
 
 .tabGroup {

--- a/src/components/Charts/Charts.tsx
+++ b/src/components/Charts/Charts.tsx
@@ -41,15 +41,24 @@ export default function Charts({ userId }: ChartsProps) {
 
   return (
     <div className={styles.chartsWrapper}>
-      {activeView === 'record' && (
+      <div
+        className={styles.chartPane}
+        style={{ display: activeView === 'record' ? 'block' : 'none' }}
+      >
         <RecordChart userId={userId} tabButtons={tabButtons} />
-      )}
-      {activeView === 'strength' && (
+      </div>
+      <div
+        className={styles.chartPane}
+        style={{ display: activeView === 'strength' ? 'block' : 'none' }}
+      >
         <StrengthChart userId={userId} tabButtons={tabButtons} />
-      )}
-      {activeView === 'bodyweight' && (
+      </div>
+      <div
+        className={styles.chartPane}
+        style={{ display: activeView === 'bodyweight' ? 'block' : 'none' }}
+      >
         <BodyweightChart userId={userId} tabButtons={tabButtons} />
-      )}
+      </div>
     </div>
   );
 }

--- a/src/components/Charts/components/BodyweightChart/BodyweightChart.module.scss
+++ b/src/components/Charts/components/BodyweightChart/BodyweightChart.module.scss
@@ -9,6 +9,9 @@
   width: 100%;
   overflow: hidden;
   min-width: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   @media (max-width: 768px) {
     padding: 20px 10px;
@@ -140,6 +143,7 @@
   .bodyweightBadge {
     display: inline-flex;
     align-items: center;
+    align-self: flex-start;
     gap: 10px;
     background: rgba($blue, 0.07);
     border: 1px solid rgba($blue, 0.2);
@@ -173,12 +177,21 @@
 
   .contentWrapper {
     width: 100%;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
 
     :global(.recharts-wrapper),
     :global(.recharts-wrapper *),
     :global(.recharts-surface),
     :global(.recharts-surface *) {
       outline: none;
+    }
+
+    .chartArea {
+      flex: 1;
+      min-height: 0;
     }
   }
 

--- a/src/components/Charts/components/BodyweightChart/BodyweightChart.tsx
+++ b/src/components/Charts/components/BodyweightChart/BodyweightChart.tsx
@@ -311,99 +311,101 @@ export default function BodyweightChart({
               </div>
             </div>
 
-            <ResponsiveContainer width='100%' height={260}>
-              <BarChart
-                data={chartData}
-                margin={{ top: 20, right: 30, bottom: 10, left: 30 }}
-                barCategoryGap='30%'
-              >
-                <CartesianGrid
-                  vertical={false}
-                  stroke='var(--border-soft, #e5e7eb)'
-                />
-
-                <XAxis
-                  dataKey='subject'
-                  axisLine={false}
-                  tickLine={false}
-                  tick={({ x, y, payload }) => {
-                    const color =
-                      COLORS[payload.value as LiftSubject] ?? '#6b7280';
-                    return (
-                      <text
-                        x={x}
-                        y={Number(y) + 12}
-                        textAnchor='middle'
-                        fill={color}
-                        fontSize={13}
-                        fontWeight={600}
-                      >
-                        {payload.value}
-                      </text>
-                    );
-                  }}
-                />
-
-                <YAxis hide domain={[0, 'dataMax + 20']} />
-
-                <Tooltip
-                  content={<CustomTooltip />}
-                  cursor={{ fill: 'rgba(0,0,0,0.03)' }}
-                />
-
-                <ReferenceLine
-                  y={100}
-                  stroke='#d1d5db'
-                  strokeDasharray='4 4'
-                  strokeWidth={1.5}
-                  label={{
-                    value: '목표',
-                    position: 'right',
-                    fill: '#9ca3af',
-                    fontSize: 11,
-                  }}
-                />
-
-                <Bar
-                  dataKey='score'
-                  radius={[6, 6, 0, 0]}
-                  maxBarSize={48}
-                  shape={(
-                    props: RectangleProps & { payload?: ChartDataItem },
-                  ) => {
-                    const { x, y, width, height, payload } = props;
-                    if (!payload) return <Rectangle {...props} />;
-
-                    const color = COLORS[payload.subject] ?? '#6b7280';
-                    const fill = payload.score >= 100 ? color : `${color}66`;
-
-                    return (
-                      <Rectangle
-                        x={x}
-                        y={y}
-                        width={width}
-                        height={height}
-                        radius={[6, 6, 0, 0]}
-                        fill={fill}
-                      />
-                    );
-                  }}
+            <div className={styles.chartArea}>
+              <ResponsiveContainer width='100%' height='100%'>
+                <BarChart
+                  data={chartData}
+                  margin={{ top: 20, right: 30, bottom: 10, left: 30 }}
+                  barCategoryGap='30%'
                 >
-                  <LabelList
-                    dataKey='ratio'
-                    position='top'
-                    formatter={(v: unknown) => {
-                      if (v === null || v === undefined) return '';
-                      const num = Number(v);
-                      return Number.isNaN(num) ? '' : `${num.toFixed(2)}배`;
-                    }}
-                    fontSize={12}
-                    fontWeight={600}
-                    fill='#374151'
+                  <CartesianGrid
+                    vertical={false}
+                    stroke='var(--border-soft, #e5e7eb)'
                   />
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+
+                  <XAxis
+                    dataKey='subject'
+                    axisLine={false}
+                    tickLine={false}
+                    tick={({ x, y, payload }) => {
+                      const color =
+                        COLORS[payload.value as LiftSubject] ?? '#6b7280';
+                      return (
+                        <text
+                          x={x}
+                          y={Number(y) + 12}
+                          textAnchor='middle'
+                          fill={color}
+                          fontSize={13}
+                          fontWeight={600}
+                        >
+                          {payload.value}
+                        </text>
+                      );
+                    }}
+                  />
+
+                  <YAxis hide domain={[0, 'dataMax + 20']} />
+
+                  <Tooltip
+                    content={<CustomTooltip />}
+                    cursor={{ fill: 'rgba(0,0,0,0.03)' }}
+                  />
+
+                  <ReferenceLine
+                    y={100}
+                    stroke='#d1d5db'
+                    strokeDasharray='4 4'
+                    strokeWidth={1.5}
+                    label={{
+                      value: '목표',
+                      position: 'right',
+                      fill: '#9ca3af',
+                      fontSize: 11,
+                    }}
+                  />
+
+                  <Bar
+                    dataKey='score'
+                    radius={[6, 6, 0, 0]}
+                    maxBarSize={48}
+                    shape={(
+                      props: RectangleProps & { payload?: ChartDataItem },
+                    ) => {
+                      const { x, y, width, height, payload } = props;
+                      if (!payload) return <Rectangle {...props} />;
+
+                      const color = COLORS[payload.subject] ?? '#6b7280';
+                      const fill = payload.score >= 100 ? color : `${color}66`;
+
+                      return (
+                        <Rectangle
+                          x={x}
+                          y={y}
+                          width={width}
+                          height={height}
+                          radius={[6, 6, 0, 0]}
+                          fill={fill}
+                        />
+                      );
+                    }}
+                  >
+                    <LabelList
+                      dataKey='ratio'
+                      position='top'
+                      formatter={(v: unknown) => {
+                        if (v === null || v === undefined) return '';
+                        const num = Number(v);
+                        return Number.isNaN(num) ? '' : `${num.toFixed(2)}배`;
+                      }}
+                      fontSize={12}
+                      fontWeight={600}
+                      fill='#374151'
+                    />
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
 
             {strongest && weakest && strongest.subject !== weakest.subject && (
               <div className={styles.summary}>

--- a/src/components/Charts/components/RecordChart/RecordChart.module.scss
+++ b/src/components/Charts/components/RecordChart/RecordChart.module.scss
@@ -8,6 +8,9 @@
   padding: 20px;
   width: 100%;
   min-width: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   @media (max-width: 768px) {
     padding: 20px 10px;
@@ -182,6 +185,15 @@
 
   .contentWrapper {
     width: 100%;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+
+    .chartArea {
+      flex: 1;
+      min-height: 0;
+    }
   }
 
   .chartWrapper {

--- a/src/components/Charts/components/RecordChart/RecordChart.tsx
+++ b/src/components/Charts/components/RecordChart/RecordChart.tsx
@@ -353,132 +353,137 @@ export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
         ) : (
           <>
             {/* 차트 */}
-            <ResponsiveContainer width='100%' height={375}>
-              <LineChart
-                data={chartData}
-                className={styles.chartWrapper}
-                margin={{ top: 10, right: 20, left: 0, bottom: 20 }}
-              >
-                {/* 가로선 표시 그리드 */}
-                <CartesianGrid
-                  strokeDasharray='3 3'
-                  vertical={false}
-                  className={styles.chartGrid}
-                />
-
-                {/* 월/일 */}
-                <XAxis
-                  dataKey='xKey'
-                  tickFormatter={(val) => {
-                    const startIndex = brushRange?.startIndex ?? 0;
-                    const endIndex =
-                      brushRange?.endIndex ?? chartData.length - 1;
-                    const visibleCount = endIndex - startIndex + 1;
-
-                    if (visibleCount <= 10) {
-                      const d = new Date(val.split('_')[0]);
-                      return `${d.getMonth() + 1}/${d.getDate()}`;
-                    }
-
-                    const currentIndex = chartData.findIndex(
-                      (d) => d.xKey === val,
-                    );
-                    if (
-                      currentIndex === startIndex ||
-                      currentIndex === endIndex
-                    ) {
-                      const d = new Date(val.split('_')[0]);
-                      return `${d.getMonth() + 1}/${d.getDate()}`;
-                    }
-                    return '';
-                  }}
-                  tick={{ className: styles.chartTick }}
-                  tickLine={false}
-                  axisLine={false}
-                  dy={10}
-                />
-
-                {/* 데이터 범위 */}
-                <YAxis
-                  domain={['dataMin - 10', 'dataMax + 10']}
-                  tick={{ className: styles.chartTick }}
-                  tickLine={false}
-                  axisLine={false}
-                  unit='kg'
-                  width={45}
-                />
-                <Tooltip
-                  content={
-                    <CustomTooltip activePart={activePart} show1RM={show1RM} />
-                  }
-                />
-
-                {/* 선택된 부위 데이터 */}
-                <Line
-                  name={activePart.label}
-                  type='monotone'
-                  connectNulls={false}
-                  dataKey={(entry) => {
-                    const point = entry as ChartDataPoint;
-                    const val = show1RM
-                      ? point[activePart.rmKey]
-                      : point[activePart.key];
-
-                    // 값이 없거나 0이면 점 미표시
-                    if (typeof val !== 'number' || val === 0) return null;
-                    return val;
-                  }}
-                  stroke={activePart.color}
-                  strokeWidth={3}
-                  dot={{ r: 4, fill: activePart.color, strokeWidth: 0 }}
-                  activeDot={{ r: 6, strokeWidth: 0 }}
-                  isAnimationActive={true}
-                />
-
-                {/* 브러쉬 슬라이더 */}
-                {brushRange && brushRange.endIndex < chartData.length && (
-                  <Brush
-                    key={activePart.key}
-                    dataKey='xKey'
-                    height={20}
-                    stroke={activePart.color}
-                    fill='transparent'
-                    startIndex={brushRange.startIndex}
-                    endIndex={brushRange.endIndex}
-                    travellerWidth={isMobile ? 0 : 8}
-                    className={styles.charBrush}
-                    y={345}
-                    tickFormatter={() => ''}
-                    onChange={(range) => {
-                      if (
-                        range.startIndex !== undefined &&
-                        range.endIndex !== undefined
-                      ) {
-                        if (isMobile) {
-                          // 윈도우 크기 고정 및 드래그로 전체 이동
-                          const size =
-                            brushRange.endIndex - brushRange.startIndex;
-                          const newStart = range.startIndex;
-                          const newEnd = Math.min(
-                            newStart + size,
-                            chartData.length - 1,
-                          );
-                          updateBrushRange({
-                            startIndex: newStart,
-                            endIndex: newEnd,
-                          });
-                        } else {
-                          updateBrushRange({
-                            startIndex: range.startIndex,
-                            endIndex: range.endIndex,
-                          });
-                        }
-                      }
-                    }}
+            <div className={styles.chartArea}>
+              <ResponsiveContainer width='100%' height='100%'>
+                <LineChart
+                  data={chartData}
+                  className={styles.chartWrapper}
+                  margin={{ top: 10, right: 20, left: 0, bottom: 20 }}
+                >
+                  {/* 가로선 표시 그리드 */}
+                  <CartesianGrid
+                    strokeDasharray='3 3'
+                    vertical={false}
+                    className={styles.chartGrid}
                   />
-                )}
-              </LineChart>
-            </ResponsiveContainer>
+
+                  {/* 월/일 */}
+                  <XAxis
+                    dataKey='xKey'
+                    tickFormatter={(val) => {
+                      const startIndex = brushRange?.startIndex ?? 0;
+                      const endIndex =
+                        brushRange?.endIndex ?? chartData.length - 1;
+                      const visibleCount = endIndex - startIndex + 1;
+
+                      if (visibleCount <= 10) {
+                        const d = new Date(val.split('_')[0]);
+                        return `${d.getMonth() + 1}/${d.getDate()}`;
+                      }
+
+                      const currentIndex = chartData.findIndex(
+                        (d) => d.xKey === val,
+                      );
+                      if (
+                        currentIndex === startIndex ||
+                        currentIndex === endIndex
+                      ) {
+                        const d = new Date(val.split('_')[0]);
+                        return `${d.getMonth() + 1}/${d.getDate()}`;
+                      }
+                      return '';
+                    }}
+                    tick={{ className: styles.chartTick }}
+                    tickLine={false}
+                    axisLine={false}
+                    dy={10}
+                  />
+
+                  {/* 데이터 범위 */}
+                  <YAxis
+                    domain={['dataMin - 10', 'dataMax + 10']}
+                    tick={{ className: styles.chartTick }}
+                    tickLine={false}
+                    axisLine={false}
+                    unit='kg'
+                    width={45}
+                  />
+                  <Tooltip
+                    content={
+                      <CustomTooltip
+                        activePart={activePart}
+                        show1RM={show1RM}
+                      />
+                    }
+                  />
+
+                  {/* 선택된 부위 데이터 */}
+                  <Line
+                    name={activePart.label}
+                    type='monotone'
+                    connectNulls={false}
+                    dataKey={(entry) => {
+                      const point = entry as ChartDataPoint;
+                      const val = show1RM
+                        ? point[activePart.rmKey]
+                        : point[activePart.key];
+
+                      // 값이 없거나 0이면 점 미표시
+                      if (typeof val !== 'number' || val === 0) return null;
+                      return val;
+                    }}
+                    stroke={activePart.color}
+                    strokeWidth={3}
+                    dot={{ r: 4, fill: activePart.color, strokeWidth: 0 }}
+                    activeDot={{ r: 6, strokeWidth: 0 }}
+                    isAnimationActive={true}
+                  />
+
+                  {/* 브러쉬 슬라이더 */}
+                  {brushRange && brushRange.endIndex < chartData.length && (
+                    <Brush
+                      key={activePart.key}
+                      dataKey='xKey'
+                      height={20}
+                      stroke={activePart.color}
+                      fill='transparent'
+                      startIndex={brushRange.startIndex}
+                      endIndex={brushRange.endIndex}
+                      travellerWidth={isMobile ? 0 : 8}
+                      className={styles.charBrush}
+                      y={345}
+                      tickFormatter={() => ''}
+                      onChange={(range) => {
+                        if (
+                          range.startIndex !== undefined &&
+                          range.endIndex !== undefined
+                        ) {
+                          if (isMobile) {
+                            // 윈도우 크기 고정 및 드래그로 전체 이동
+                            const size =
+                              brushRange.endIndex - brushRange.startIndex;
+                            const newStart = range.startIndex;
+                            const newEnd = Math.min(
+                              newStart + size,
+                              chartData.length - 1,
+                            );
+                            updateBrushRange({
+                              startIndex: newStart,
+                              endIndex: newEnd,
+                            });
+                          } else {
+                            updateBrushRange({
+                              startIndex: range.startIndex,
+                              endIndex: range.endIndex,
+                            });
+                          }
+                        }
+                      }}
+                    />
+                  )}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
 
             {/* 브러쉬 내비게이션 버튼 */}
             {(!isMobile ||

--- a/src/components/Charts/components/StrengthChart/StrengthChart.module.scss
+++ b/src/components/Charts/components/StrengthChart/StrengthChart.module.scss
@@ -9,6 +9,9 @@
   width: 100%;
   overflow: hidden;
   min-width: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   @media (max-width: 768px) {
     padding: 20px 10px;
@@ -139,11 +142,20 @@
 
   .contentWrapper {
     width: 100%;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
     :global(.recharts-wrapper),
     :global(.recharts-wrapper *),
     :global(.recharts-surface),
     :global(.recharts-surface *) {
       outline: none;
+    }
+
+    .chartArea {
+      flex: 1;
+      min-height: 0;
     }
 
     .scoreList {

--- a/src/components/Charts/components/StrengthChart/StrengthChart.tsx
+++ b/src/components/Charts/components/StrengthChart/StrengthChart.tsx
@@ -228,59 +228,62 @@ export default function StrengthChart({
           />
         ) : (
           <>
-            <ResponsiveContainer width='100%' height={285}>
-              <RadarChart
-                accessibilityLayer={false}
-                data={chartData}
-                margin={{ top: 10, right: 30, bottom: 10, left: 30 }}
-              >
-                <PolarGrid stroke='var(--border-soft, #e5e7eb)' />
-                <PolarAngleAxis
-                  dataKey='subject'
-                  tick={({ x, y, payload }) => {
-                    const color =
-                      COLORS[payload.value as keyof typeof COLORS] ?? '#6b7280';
+            <div className={styles.chartArea}>
+              <ResponsiveContainer width='100%' height='100%'>
+                <RadarChart
+                  accessibilityLayer={false}
+                  data={chartData}
+                  margin={{ top: 10, right: 30, bottom: 10, left: 30 }}
+                >
+                  <PolarGrid stroke='var(--border-soft, #e5e7eb)' />
+                  <PolarAngleAxis
+                    dataKey='subject'
+                    tick={({ x, y, payload }) => {
+                      const color =
+                        COLORS[payload.value as keyof typeof COLORS] ??
+                        '#6b7280';
 
-                    return (
-                      <text
-                        x={x}
-                        y={y}
-                        textAnchor='middle'
-                        dominantBaseline='central'
-                        fill={color}
-                        fontSize={13}
-                        fontWeight={600}
-                      >
-                        {payload.value}
-                      </text>
-                    );
-                  }}
-                />
+                      return (
+                        <text
+                          x={x}
+                          y={y}
+                          textAnchor='middle'
+                          dominantBaseline='central'
+                          fill={color}
+                          fontSize={13}
+                          fontWeight={600}
+                        >
+                          {payload.value}
+                        </text>
+                      );
+                    }}
+                  />
 
-                <Tooltip content={<CustomTooltip />} cursor={false} />
+                  <Tooltip content={<CustomTooltip />} cursor={false} />
 
-                <Radar
-                  name='기준'
-                  dataKey={() => 100}
-                  stroke='#d1d5db'
-                  fill='#f3f4f6'
-                  fillOpacity={0.4}
-                  strokeDasharray='4 4'
-                  strokeWidth={1.5}
-                  dot={false}
-                />
+                  <Radar
+                    name='기준'
+                    dataKey={() => 100}
+                    stroke='#d1d5db'
+                    fill='#f3f4f6'
+                    fillOpacity={0.4}
+                    strokeDasharray='4 4'
+                    strokeWidth={1.5}
+                    dot={false}
+                  />
 
-                <Radar
-                  name='수치'
-                  dataKey='score'
-                  stroke='#007bff'
-                  fill='#007bff'
-                  fillOpacity={0.2}
-                  strokeWidth={2.5}
-                  dot={{ r: 4, fill: '#007bff', strokeWidth: 0 }}
-                />
-              </RadarChart>
-            </ResponsiveContainer>
+                  <Radar
+                    name='수치'
+                    dataKey='score'
+                    stroke='#007bff'
+                    fill='#007bff'
+                    fillOpacity={0.2}
+                    strokeWidth={2.5}
+                    dot={{ r: 4, fill: '#007bff', strokeWidth: 0 }}
+                  />
+                </RadarChart>
+              </ResponsiveContainer>
+            </div>
 
             <div className={styles.scoreList}>
               {chartData.map((item) => {


### PR DESCRIPTION
### 작업 내용

**차트 높이 반응형 처리** (`StrengthChart`, `RecordChart`, `BodyweightChart`)
- 각 컴포넌트의 `ResponsiveContainer`를 `chartArea` 래퍼로 감싸고 고정 `height` 값 대신 `height='100%'`로 변경
- `container`를 flex 컬럼 레이아웃으로 구성하고 `height: 100%` 적용
- `contentWrapper`, `chartArea`를 `flex: 1` + `min-height`: 0으로 구성해 남는 공간을 자동으로 채우도록 수정

**차트 탭 전환 시 상태 유지** (`Charts.tsx`)
- 조건부 렌더링(마운트/언마운트) 방식에서 세 차트를 모두 항상 마운트해두고 `display: none/block`으로 노출 여부만 전환하는 방식으로 변경
- 탭 전환 시 `useRecords`/`useProfile` 재요청, 브러쉬 범위 초기화가 발생하지 않도록 개선

**차트 탭 영역 고정 높이 적용** (`Charts.module.scss`)
- `chartPane`에 고정 높이(`$chart-height` / `$chart-height-mobile`) 적용
- 각 차트 컴포넌트의 `height: 100%`가 유효한 기준을 갖도록 지원
- 항상 마운트된 상태에서도 탭 전환 시 레이아웃이 흔들리지 않도록 안정화