### PR TITLE
feat: 데이터 부재 시 차트 레이아웃 높이 자동 조정 기능 추가

### DIFF
--- a/src/components/Charts/Charts.module.scss
+++ b/src/components/Charts/Charts.module.scss
@@ -13,6 +13,10 @@ $chart-height-mobile: 650px;
   @media (max-width: 768px) {
     height: $chart-height-mobile;
   }
+
+  &.auto {
+    height: auto;
+  }
 }
 
 .tabGroup {

--- a/src/components/Charts/Charts.tsx
+++ b/src/components/Charts/Charts.tsx
@@ -9,10 +9,7 @@ import BodyweightChart from './components/BodyweightChart/BodyweightChart';
 
 import styles from './Charts.module.scss';
 
-type ChartsProps = {
-  userId?: string;
-};
-
+type ChartsProps = { userId?: string };
 type ChartView = 'record' | 'strength' | 'bodyweight';
 
 const TABS: { key: ChartView; label: string; icon: React.ReactNode }[] = [
@@ -23,6 +20,17 @@ const TABS: { key: ChartView; label: string; icon: React.ReactNode }[] = [
 
 export default function Charts({ userId }: ChartsProps) {
   const [activeView, setActiveView] = useState<ChartView>('record');
+  const [hasData, setHasData] = useState<Record<ChartView, boolean>>({
+    record: true,
+    strength: true,
+    bodyweight: true,
+  });
+
+  const handleHasDataChange = (view: ChartView) => (value: boolean) => {
+    setHasData((prev) =>
+      prev[view] === value ? prev : { ...prev, [view]: value },
+    );
+  };
 
   const tabButtons = (
     <div className={styles.tabGroup}>
@@ -42,22 +50,34 @@ export default function Charts({ userId }: ChartsProps) {
   return (
     <div className={styles.chartsWrapper}>
       <div
-        className={styles.chartPane}
+        className={`${styles.chartPane} ${!hasData.record ? styles.auto : ''}`}
         style={{ display: activeView === 'record' ? 'block' : 'none' }}
       >
-        <RecordChart userId={userId} tabButtons={tabButtons} />
+        <RecordChart
+          userId={userId}
+          tabButtons={tabButtons}
+          onHasDataChange={handleHasDataChange('record')}
+        />
       </div>
       <div
-        className={styles.chartPane}
+        className={`${styles.chartPane} ${!hasData.strength ? styles.auto : ''}`}
         style={{ display: activeView === 'strength' ? 'block' : 'none' }}
       >
-        <StrengthChart userId={userId} tabButtons={tabButtons} />
+        <StrengthChart
+          userId={userId}
+          tabButtons={tabButtons}
+          onHasDataChange={handleHasDataChange('strength')}
+        />
       </div>
       <div
-        className={styles.chartPane}
+        className={`${styles.chartPane} ${!hasData.bodyweight ? styles.auto : ''}`}
         style={{ display: activeView === 'bodyweight' ? 'block' : 'none' }}
       >
-        <BodyweightChart userId={userId} tabButtons={tabButtons} />
+        <BodyweightChart
+          userId={userId}
+          tabButtons={tabButtons}
+          onHasDataChange={handleHasDataChange('bodyweight')}
+        />
       </div>
     </div>
   );

--- a/src/components/Charts/components/BodyweightChart/BodyweightChart.module.scss
+++ b/src/components/Charts/components/BodyweightChart/BodyweightChart.module.scss
@@ -189,6 +189,14 @@
       outline: none;
     }
 
+    .stateWrapper {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
     .chartArea {
       flex: 1;
       min-height: 0;

--- a/src/components/Charts/components/BodyweightChart/BodyweightChart.tsx
+++ b/src/components/Charts/components/BodyweightChart/BodyweightChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import {
   BarChart,
   Bar,
@@ -42,6 +42,7 @@ import styles from './BodyweightChart.module.scss';
 type BodyweightChartProps = {
   userId?: string;
   tabButtons?: React.ReactNode;
+  onHasDataChange?: (hasData: boolean) => void;
 };
 
 type ChartDataItem = {
@@ -93,6 +94,7 @@ const CustomTooltip = ({
 export default function BodyweightChart({
   userId,
   tabButtons,
+  onHasDataChange,
 }: BodyweightChartProps) {
   const { user } = useAuth();
   const targetId = userId || user?.id;
@@ -166,6 +168,12 @@ export default function BodyweightChart({
     !!bodyweight &&
     !!gender &&
     !!ageBracket;
+
+  useEffect(() => {
+    if (!isPageLoading) {
+      onHasDataChange?.(hasEnoughData);
+    }
+  }, [isPageLoading, hasEnoughData, onHasDataChange]);
 
   const strongest = chartData.length
     ? chartData.reduce((a, b) => (a.score > b.score ? a : b))
@@ -257,39 +265,49 @@ export default function BodyweightChart({
 
       <div className={styles.contentWrapper}>
         {isPageLoading ? (
-          <Loading message='체중 대비 데이터를 분석하고 있어요!' />
+          <div className={styles.stateWrapper}>
+            <Loading message='체중 대비 데이터를 분석하고 있어요!' />
+          </div>
         ) : noWeight ? (
-          <Empty
-            message='체중 정보가 없어요.'
-            subMessage={
-              isReadOnly
-                ? `${displayName}님이 아직 체중을 등록하지 않았어요.`
-                : '프로필 수정에서 체중을 입력하면 체중 대비 밸런스를 확인할 수 있어요!'
-            }
-          />
+          <div className={styles.stateWrapper}>
+            <Empty
+              message='체중 정보가 없어요.'
+              subMessage={
+                isReadOnly
+                  ? `${displayName}님이 아직 체중을 등록하지 않았어요.`
+                  : '프로필 수정에서 체중을 입력하면 체중 대비 밸런스를 확인할 수 있어요!'
+              }
+            />
+          </div>
         ) : noGender ? (
-          <Empty
-            message='성별 정보가 없어요.'
-            subMessage={
-              isReadOnly
-                ? `${displayName}님이 아직 성별을 등록하지 않았어요.`
-                : '프로필 수정에서 성별을 입력하면 체중 대비 밸런스를 확인할 수 있어요!'
-            }
-          />
+          <div className={styles.stateWrapper}>
+            <Empty
+              message='성별 정보가 없어요.'
+              subMessage={
+                isReadOnly
+                  ? `${displayName}님이 아직 성별을 등록하지 않았어요.`
+                  : '프로필 수정에서 성별을 입력하면 체중 대비 밸런스를 확인할 수 있어요!'
+              }
+            />
+          </div>
         ) : noBirthDate ? (
-          <Empty
-            message='생년월일 정보가 없어요.'
-            subMessage={
-              isReadOnly
-                ? `${displayName}님이 아직 생년월일을 등록하지 않았어요.`
-                : '프로필 수정에서 생년월일을 입력하면 체중 대비 밸런스를 확인할 수 있어요!'
-            }
-          />
+          <div className={styles.stateWrapper}>
+            <Empty
+              message='생년월일 정보가 없어요.'
+              subMessage={
+                isReadOnly
+                  ? `${displayName}님이 아직 생년월일을 등록하지 않았어요.`
+                  : '프로필 수정에서 생년월일을 입력하면 체중 대비 밸런스를 확인할 수 있어요!'
+              }
+            />
+          </div>
         ) : !hasEnoughData ? (
-          <Empty
-            message='밸런스 분석을 위한 데이터가 부족합니다.'
-            subMessage='스쿼트, 데드리프트, 벤치프레스 기록이 필요해요.'
-          />
+          <div className={styles.stateWrapper}>
+            <Empty
+              message='밸런스 분석을 위한 데이터가 부족합니다.'
+              subMessage='스쿼트, 데드리프트, 벤치프레스 기록이 필요해요.'
+            />
+          </div>
         ) : (
           <>
             <div className={styles.bodyweightBadge}>

--- a/src/components/Charts/components/RecordChart/RecordChart.module.scss
+++ b/src/components/Charts/components/RecordChart/RecordChart.module.scss
@@ -190,6 +190,14 @@
     display: flex;
     flex-direction: column;
 
+    .stateWrapper {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
     .chartArea {
       flex: 1;
       min-height: 0;

--- a/src/components/Charts/components/RecordChart/RecordChart.tsx
+++ b/src/components/Charts/components/RecordChart/RecordChart.tsx
@@ -33,6 +33,7 @@ import styles from './RecordChart.module.scss';
 type RecordChartProps = {
   userId?: string;
   tabButtons?: React.ReactNode;
+  onHasDataChange?: (hasData: boolean) => void;
 };
 
 type ChartPart = {
@@ -109,7 +110,11 @@ const calc1RM = (weight: number, reps: number): number => {
   return Math.round(weight * (1 + reps / 30));
 };
 
-export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
+export default function RecordChart({
+  userId,
+  tabButtons,
+  onHasDataChange,
+}: RecordChartProps) {
   const { user } = useAuth();
   const targetId = userId || user?.id;
 
@@ -256,6 +261,12 @@ export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
     setBrushRange(next);
   };
 
+  useEffect(() => {
+    if (!isPageLoading) {
+      onHasDataChange?.(chartData.length >= 2);
+    }
+  }, [isPageLoading, chartData.length, onHasDataChange]);
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -336,20 +347,24 @@ export default function RecordChart({ userId, tabButtons }: RecordChartProps) {
 
       <div className={styles.contentWrapper}>
         {isPageLoading ? (
-          <Loading message='차트 데이터를 분석하고 있어요!' />
+          <div className={styles.stateWrapper}>
+            <Loading message='차트 데이터를 분석하고 있어요!' />
+          </div>
         ) : chartData.length < 2 ? (
-          <Empty
-            message={
-              isReadOnly
-                ? `${displayName}님의 차트 데이터가 부족합니다.`
-                : '최소 2개 이상의 기록이 필요합니다.'
-            }
-            subMessage={
-              !isReadOnly
-                ? '오늘의 운동을 기록하고 성장 곡선을 확인해보세요!'
-                : '아직 등록된 기록이 충분하지 않아요.'
-            }
-          />
+          <div className={styles.stateWrapper}>
+            <Empty
+              message={
+                isReadOnly
+                  ? `${displayName}님의 차트 데이터가 부족합니다.`
+                  : '최소 2개 이상의 기록이 필요합니다.'
+              }
+              subMessage={
+                !isReadOnly
+                  ? '오늘의 운동을 기록하고 성장 곡선을 확인해보세요!'
+                  : '아직 등록된 기록이 충분하지 않아요.'
+              }
+            />
+          </div>
         ) : (
           <>
             {/* 차트 */}

--- a/src/components/Charts/components/StrengthChart/StrengthChart.module.scss
+++ b/src/components/Charts/components/StrengthChart/StrengthChart.module.scss
@@ -153,6 +153,14 @@
       outline: none;
     }
 
+    .stateWrapper {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
     .chartArea {
       flex: 1;
       min-height: 0;

--- a/src/components/Charts/components/StrengthChart/StrengthChart.tsx
+++ b/src/components/Charts/components/StrengthChart/StrengthChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import {
   RadarChart,
   Radar,
@@ -25,6 +25,7 @@ import styles from './StrengthChart.module.scss';
 type StrengthChartProps = {
   userId?: string;
   tabButtons?: React.ReactNode;
+  onHasDataChange?: (hasData: boolean) => void;
 };
 
 const STANDARD_RATIOS: Record<string, number> = {
@@ -104,6 +105,7 @@ const CustomTooltip = ({
 export default function StrengthChart({
   userId,
   tabButtons,
+  onHasDataChange,
 }: StrengthChartProps) {
   const { user } = useAuth();
   const targetId = userId || user?.id;
@@ -159,6 +161,12 @@ export default function StrengthChart({
     bestRecords.squat1rm > 0 &&
     bestRecords.deadlift1rm > 0 &&
     bestRecords.bench1rm > 0;
+
+  useEffect(() => {
+    if (!isPageLoading) {
+      onHasDataChange?.(hasEnoughData);
+    }
+  }, [isPageLoading, hasEnoughData, onHasDataChange]);
 
   const strongest = chartData.length
     ? chartData.reduce((a, b) => (a.score > b.score ? a : b))
@@ -220,12 +228,16 @@ export default function StrengthChart({
 
       <div className={styles.contentWrapper}>
         {isPageLoading ? (
-          <Loading message='밸런스를 분석하고 있어요' />
+          <div className={styles.stateWrapper}>
+            <Loading message='밸런스를 분석하고 있어요' />
+          </div>
         ) : !hasEnoughData ? (
-          <Empty
-            message='밸런스 분석을 위한 데이터가 부족합니다.'
-            subMessage='스쿼트, 데드리프트, 벤치프레스 기록이 필요해요.'
-          />
+          <div className={styles.stateWrapper}>
+            <Empty
+              message='밸런스 분석을 위한 데이터가 부족합니다.'
+              subMessage='스쿼트, 데드리프트, 벤치프레스 기록이 필요해요.'
+            />
+          </div>
         ) : (
           <>
             <div className={styles.chartArea}>


### PR DESCRIPTION
**차트별 데이터 존재 여부 콜백 전달**
- `StrengthChart`, `RecordChart`, `BodyweightChart`에 `onHasDataChange` prop 추가
- 각 컴포넌트의 로딩이 끝난 시점에 데이터 존재 여부(`hasEnoughData` / `chartData.length >= 2`)를 상위 컴포넌트로 전달

**Charts 컴포넌트에서 상태 관리 및 높이 제어**
- `Charts`에서 `hasData` 상태로 각 탭(record/strength/bodyweight)의 데이터 존재 여부 관리
- 데이터가 없는 탭의 `chartPane`에 `auto` 클래스를 적용해 고정 높이(610px / 모바일 650px) 해제

**로딩/빈 상태 UI 레이아웃 개선**
- 각 차트의 `contentWrapper` 내부에 `stateWrapper` 클래스를 추가
- `Loading`, `Empty` 컴포넌트를 flex 중앙 정렬로 배치하여 상태 UI가 영역 중앙에 위치하도록 처리
