### PR TITLE
fix: 차트 렌더링 안정성 개선

### DIFF
--- a/src/components/Charts/Charts.module.scss
+++ b/src/components/Charts/Charts.module.scss
@@ -4,19 +4,38 @@ $chart-height: 610px;
 $chart-height-mobile: 650px;
 
 .chartsWrapper {
+  position: relative;
   width: 100%;
-}
-
-.chartPane {
   height: $chart-height;
 
   @media (max-width: 768px) {
     height: $chart-height-mobile;
   }
+}
+
+.chartPane {
+  position: absolute;
+  inset: 0;
+  height: 100%;
+  transition: opacity 0.15s ease;
 
   &.auto {
     height: auto;
   }
+}
+
+.active {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 1;
+}
+
+.inactive {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 0;
 }
 
 .tabGroup {

--- a/src/components/Charts/Charts.tsx
+++ b/src/components/Charts/Charts.tsx
@@ -20,11 +20,23 @@ const TABS: { key: ChartView; label: string; icon: React.ReactNode }[] = [
 
 export default function Charts({ userId }: ChartsProps) {
   const [activeView, setActiveView] = useState<ChartView>('record');
+  const [mountedViews, setMountedViews] = useState<Record<ChartView, boolean>>({
+    record: true,
+    strength: false,
+    bodyweight: false,
+  });
   const [hasData, setHasData] = useState<Record<ChartView, boolean>>({
     record: true,
     strength: true,
     bodyweight: true,
   });
+
+  const handleTabClick = (view: ChartView) => {
+    setActiveView(view);
+    setMountedViews((prev) =>
+      prev[view] ? prev : { ...prev, [view]: true },
+    );
+  };
 
   const handleHasDataChange = (view: ChartView) => (value: boolean) => {
     setHasData((prev) =>
@@ -39,7 +51,7 @@ export default function Charts({ userId }: ChartsProps) {
           key={tab.key}
           type='button'
           className={`${styles.tabBtn} ${activeView === tab.key ? styles.active : ''}`}
-          onClick={() => setActiveView(tab.key)}
+          onClick={() => handleTabClick(tab.key)}
         >
           {tab.icon}
         </button>
@@ -49,36 +61,47 @@ export default function Charts({ userId }: ChartsProps) {
 
   return (
     <div className={styles.chartsWrapper}>
-      <div
-        className={`${styles.chartPane} ${!hasData.record ? styles.auto : ''}`}
-        style={{ display: activeView === 'record' ? 'block' : 'none' }}
-      >
-        <RecordChart
-          userId={userId}
-          tabButtons={tabButtons}
-          onHasDataChange={handleHasDataChange('record')}
-        />
-      </div>
-      <div
-        className={`${styles.chartPane} ${!hasData.strength ? styles.auto : ''}`}
-        style={{ display: activeView === 'strength' ? 'block' : 'none' }}
-      >
-        <StrengthChart
-          userId={userId}
-          tabButtons={tabButtons}
-          onHasDataChange={handleHasDataChange('strength')}
-        />
-      </div>
-      <div
-        className={`${styles.chartPane} ${!hasData.bodyweight ? styles.auto : ''}`}
-        style={{ display: activeView === 'bodyweight' ? 'block' : 'none' }}
-      >
-        <BodyweightChart
-          userId={userId}
-          tabButtons={tabButtons}
-          onHasDataChange={handleHasDataChange('bodyweight')}
-        />
-      </div>
+      {mountedViews.record && (
+        <div
+          className={`${styles.chartPane} ${
+            activeView === 'record' ? styles.active : styles.inactive
+          } ${!hasData.record ? styles.auto : ''}`}
+        >
+          <RecordChart
+            userId={userId}
+            tabButtons={tabButtons}
+            onHasDataChange={handleHasDataChange('record')}
+          />
+        </div>
+      )}
+
+      {mountedViews.strength && (
+        <div
+          className={`${styles.chartPane} ${
+            activeView === 'strength' ? styles.active : styles.inactive
+          } ${!hasData.strength ? styles.auto : ''}`}
+        >
+          <StrengthChart
+            userId={userId}
+            tabButtons={tabButtons}
+            onHasDataChange={handleHasDataChange('strength')}
+          />
+        </div>
+      )}
+
+      {mountedViews.bodyweight && (
+        <div
+          className={`${styles.chartPane} ${
+            activeView === 'bodyweight' ? styles.active : styles.inactive
+          } ${!hasData.bodyweight ? styles.auto : ''}`}
+        >
+          <BodyweightChart
+            userId={userId}
+            tabButtons={tabButtons}
+            onHasDataChange={handleHasDataChange('bodyweight')}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Charts/components/BodyweightChart/BodyweightChart.module.scss
+++ b/src/components/Charts/components/BodyweightChart/BodyweightChart.module.scss
@@ -199,7 +199,7 @@
 
     .chartArea {
       flex: 1;
-      min-height: 0;
+      min-height: 200px;
     }
   }
 

--- a/src/components/Charts/components/BodyweightChart/BodyweightChart.tsx
+++ b/src/components/Charts/components/BodyweightChart/BodyweightChart.tsx
@@ -23,6 +23,9 @@ import { useRecords } from '@/hooks/useRecords';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 
+import { getBest1RM } from '@/utils/recordUtils';
+import { calculateAge } from '@/utils/dateUtils';
+
 import {
   LIFT_SUBJECTS,
   COLORS,
@@ -33,9 +36,6 @@ import {
   type Gender,
   type AgeBracket,
 } from '../../constants/strengthStandards';
-
-import { getBest1RM } from '@/utils/recordUtils';
-import { calculateAge } from '@/utils/dateUtils';
 
 import styles from './BodyweightChart.module.scss';
 
@@ -330,7 +330,11 @@ export default function BodyweightChart({
             </div>
 
             <div className={styles.chartArea}>
-              <ResponsiveContainer width='100%' height='100%'>
+              <ResponsiveContainer
+                width='100%'
+                height='100%'
+                initialDimension={{ width: 320, height: 200 }}
+              >
                 <BarChart
                   data={chartData}
                   margin={{ top: 20, right: 30, bottom: 10, left: 30 }}

--- a/src/components/Charts/components/RecordChart/RecordChart.module.scss
+++ b/src/components/Charts/components/RecordChart/RecordChart.module.scss
@@ -200,7 +200,7 @@
 
     .chartArea {
       flex: 1;
-      min-height: 0;
+      min-height: 200px;
     }
   }
 

--- a/src/components/Charts/components/RecordChart/RecordChart.tsx
+++ b/src/components/Charts/components/RecordChart/RecordChart.tsx
@@ -80,7 +80,6 @@ const PARTS: ChartPart[] = [
 ];
 
 const VISIBLE_COUNT = 10;
-const MOBILE_VISIBLE_COUNT = 6;
 
 let savedBrushRange: BrushRange | undefined = undefined;
 
@@ -136,7 +135,6 @@ export default function RecordChart({
     return () => window.removeEventListener('resize', check);
   }, []);
 
-  const visibleCount = isMobile ? MOBILE_VISIBLE_COUNT : VISIBLE_COUNT;
   const isPageLoading = recordsLoading || (isReadOnly && profileLoading);
 
   const chartData = useMemo(() => {
@@ -190,7 +188,6 @@ export default function RecordChart({
     { startIndex: number; endIndex: number } | undefined
   >(savedBrushRange);
 
-  const prevVisibleCountRef = useRef(visibleCount);
   const prevActivePartRef = useRef(activePart.key);
 
   // 브러쉬 리셋
@@ -202,14 +199,10 @@ export default function RecordChart({
   // 브러쉬 범위 계산 및 세팅
   useEffect(() => {
     if (chartData.length < 2) return;
-
-    const visibleCountChanged = prevVisibleCountRef.current !== visibleCount;
     const activePartChanged = prevActivePartRef.current !== activePart.key;
-
-    prevVisibleCountRef.current = visibleCount;
     prevActivePartRef.current = activePart.key;
 
-    if (savedBrushRange && !visibleCountChanged && !activePartChanged) {
+    if (savedBrushRange && !activePartChanged) {
       const startIndex = Math.round(
         savedBrushRange.startRatio * (chartData.length - 1),
       );
@@ -219,10 +212,10 @@ export default function RecordChart({
 
       if (startIndex >= endIndex) {
         const fallback: BrushRange = {
-          startIndex: Math.max(0, chartData.length - visibleCount),
+          startIndex: Math.max(0, chartData.length - VISIBLE_COUNT),
           endIndex: chartData.length - 1,
           startRatio:
-            Math.max(0, chartData.length - visibleCount) /
+            Math.max(0, chartData.length - VISIBLE_COUNT) /
             (chartData.length - 1),
           endRatio: 1,
         };
@@ -234,8 +227,8 @@ export default function RecordChart({
       return;
     }
 
-    if (chartData.length > visibleCount) {
-      const startIndex = chartData.length - visibleCount;
+    if (chartData.length > VISIBLE_COUNT) {
+      const startIndex = chartData.length - VISIBLE_COUNT;
       const endIndex = chartData.length - 1;
       const initial: BrushRange = {
         startIndex,
@@ -249,7 +242,7 @@ export default function RecordChart({
       savedBrushRange = undefined;
       setBrushRange(undefined);
     }
-  }, [chartData.length, activePart.key, visibleCount]);
+  }, [chartData.length, activePart.key]);
 
   // 브러쉬 범위 업데이트
   const updateBrushRange = (next: { startIndex: number; endIndex: number }) => {
@@ -369,7 +362,11 @@ export default function RecordChart({
           <>
             {/* 차트 */}
             <div className={styles.chartArea}>
-              <ResponsiveContainer width='100%' height='100%'>
+              <ResponsiveContainer
+                width='100%'
+                height='100%'
+                initialDimension={{ width: 320, height: 200 }}
+              >
                 <LineChart
                   data={chartData}
                   className={styles.chartWrapper}
@@ -391,7 +388,7 @@ export default function RecordChart({
                         brushRange?.endIndex ?? chartData.length - 1;
                       const visibleCount = endIndex - startIndex + 1;
 
-                      if (visibleCount <= 10) {
+                      if (visibleCount <= 9) {
                         const d = new Date(val.split('_')[0]);
                         return `${d.getMonth() + 1}/${d.getDate()}`;
                       }
@@ -451,7 +448,7 @@ export default function RecordChart({
                     strokeWidth={3}
                     dot={{ r: 4, fill: activePart.color, strokeWidth: 0 }}
                     activeDot={{ r: 6, strokeWidth: 0 }}
-                    isAnimationActive={true}
+                    isAnimationActive={false}
                   />
 
                   {/* 브러쉬 슬라이더 */}

--- a/src/components/Charts/components/StrengthChart/StrengthChart.module.scss
+++ b/src/components/Charts/components/StrengthChart/StrengthChart.module.scss
@@ -163,7 +163,7 @@
 
     .chartArea {
       flex: 1;
-      min-height: 0;
+      min-height: 200px;
     }
 
     .scoreList {

--- a/src/components/Charts/components/StrengthChart/StrengthChart.tsx
+++ b/src/components/Charts/components/StrengthChart/StrengthChart.tsx
@@ -241,7 +241,11 @@ export default function StrengthChart({
         ) : (
           <>
             <div className={styles.chartArea}>
-              <ResponsiveContainer width='100%' height='100%'>
+              <ResponsiveContainer
+                width='100%'
+                height='100%'
+                initialDimension={{ width: 320, height: 200 }}
+              >
                 <RadarChart
                   accessibilityLayer={false}
                   data={chartData}


### PR DESCRIPTION
### 작업 내용
**차트 초기 렌더링 크기 이슈 수정**
- `StrengthChart`, `BodyweightChart`, `RecordChart`의 `ResponsiveContainer`에
  `initialDimension={{ width: 320, height: 200 }}` 추가
  - 컨테이너 크기가 측정되기 전 차트가 0px로 렌더링되던 문제 방지
- 각 차트 scss의 `.chartArea`에 `min-height: 200px` 지정
  - flex 레이아웃에서 차트 영역이 0으로 찌그러지는 문제 방지

**`RecordChart` 추가 개선**
- 모바일 여부와 무관하게 브러시 표시 개수를 `VISIBLE_COUNT(10)`로 통일
  (`MOBILE_VISIBLE_COUNT`, 관련 분기 로직 제거)
- X축 틱 라벨 표시 기준값 조정 (10 -> 9)
- `Line`의 `isAnimationActive`를 `false`로 변경해 불필요한 애니메이션 제거

**`Charts` 탭 전환 방식 개선**
- 초기 진입 시 활성 탭(`record`)만 마운트하고 나머지 탭은 클릭 시점에
  지연 마운트(`mountedViews`)하도록 변경
  - 미사용 탭까지 렌더링/데이터 요청되던 비효율 개선
- 탭 전환을 `display: none/block` 대신 `position: absolute` 오버레이 +
  `active/inactive` 클래스(`visibility`, `opacity`, `pointer-events`)로 변경
  - 전환 시 페이드 효과 추가 (`transition: opacity 0.15s`)
