### PR TITLE
fix: 프로필 데이터 동기화 버그 수정 및 편집 UI 개선

### DIFF
--- a/src/components/Profile/Profile.module.scss
+++ b/src/components/Profile/Profile.module.scss
@@ -2,7 +2,7 @@
 
 .profileContainer {
   width: 100%;
-  border-radius: 16px;
+  border-radius: $radius-main;
   overflow: hidden;
   border: 1px solid $border-soft;
   box-shadow: $shadow-md;
@@ -21,12 +21,13 @@
   right: 0;
   bottom: 0;
   background: $white;
-  border-radius: 24px 24px 0 0;
+  border-radius: 16px 16px 0 0;
   box-shadow: $shadow-lg;
   display: grid;
   grid-template-rows: auto 0fr;
   transition: grid-template-rows 0.4s cubic-bezier(0.32, 0.72, 0, 1);
   overflow: hidden;
+  max-height: 100%;
 
   &.stage2,
   &.isEditing {
@@ -86,8 +87,15 @@
   .infoContent {
     grid-row: 2;
     min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
     transition: visibility 0.4s;
     visibility: hidden;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
 
     .contentBox {
       padding: 0 24px 15px;

--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -4,12 +4,6 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import CharacterView from './components/CharacterView/CharacterView';
-import ProfileEdit from './components/ProfileEdit/ProfileEdit';
-import ProfileInfo from './components/ProfileInfo/ProfileInfo';
-import StatsSection from './components/StatsSection/StatsSection';
-import ActionsSection from './components/ActionsSection/ActionsSection';
-
 import Loading from '@/components/shared/Loading/Loading';
 import Empty from '@/components/shared/Empty/Empty';
 import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
@@ -22,6 +16,12 @@ import { useSubscription } from '@/hooks/useSubscription';
 import { useNotificationToggle } from '@/hooks/useNotificationToggle';
 
 import { calculateTotalPR } from '@/utils/recordUtils';
+
+import CharacterView from './components/CharacterView/CharacterView';
+import ProfileEdit from './components/ProfileEdit/ProfileEdit';
+import ProfileInfo from './components/ProfileInfo/ProfileInfo';
+import StatsSection from './components/StatsSection/StatsSection';
+import ActionsSection from './components/ActionsSection/ActionsSection';
 
 import styles from './Profile.module.scss';
 
@@ -84,6 +84,7 @@ export default function ProfileCard({
 
     if (success) {
       queryClient.invalidateQueries({ queryKey: ['profile', targetId] });
+      queryClient.invalidateQueries({ queryKey: ['users'] });
       setIsEditing(false);
     }
   };
@@ -182,6 +183,7 @@ export default function ProfileCard({
                 nickname={profile.nickname}
                 avatarUrl={profile.avatar_url}
                 status={profile.status_message}
+                gender={profile.gender}
               />
             ) : null}
           </div>

--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.module.scss
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.module.scss
@@ -71,6 +71,16 @@
       gap: 14px;
       width: 100%;
 
+      .fieldRow {
+        display: flex;
+        gap: 10px;
+
+        .field {
+          flex: 1;
+          min-width: 0;
+        }
+      }
+
       .field {
         display: flex;
         flex-direction: column;
@@ -92,7 +102,7 @@
             width: 100%;
             border: 1.5px solid $border-soft;
             border-radius: $radius-main;
-            padding: 10px 44px 10px 12px;
+            padding: 10px 25px 10px 12px;
             outline: none;
             background: $off-white;
             color: $text-dark;
@@ -109,6 +119,10 @@
               color: $gray;
               font-weight: $font-light;
             }
+          }
+
+          .dateInput {
+            padding-right: 12px;
           }
 
           span {
@@ -141,10 +155,17 @@
             background 0.2s,
             color 0.2s;
 
-          &.active {
+          &.male.active {
             border-color: $blue;
             background: rgba($blue, 0.07);
             color: $blue;
+            font-weight: 600;
+          }
+
+          &.female.active {
+            border-color: $pink;
+            background: rgba($pink, 0.08);
+            color: $pink;
             font-weight: 600;
           }
         }
@@ -166,11 +187,44 @@
     display: flex;
     gap: 8px;
     width: 100%;
-    padding-top: 10px;
+    padding-top: 14px;
     border-top: 1px solid $border-soft;
 
     button {
       flex: 1;
+    }
+  }
+
+  .dangerZone {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    width: 100%;
+    padding-top: 14px;
+    padding-bottom: 4px;
+
+    .dangerLink {
+      @include font-sm;
+      background: none;
+      border: none;
+      padding: 4px 2px;
+      color: $text-muted;
+      text-decoration: underline;
+      text-underline-offset: 3px;
+      cursor: pointer;
+      transition: color 0.2s;
+
+      &:hover {
+        color: $text-dark;
+      }
+    }
+
+    .deleteLink {
+      color: rgba($red, 0.6);
+
+      &:hover {
+        color: $red;
+      }
     }
   }
 }

--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
@@ -287,33 +287,22 @@ export default function ProfileEdit({
           </div>
 
           <div className={styles.field}>
-            <label>체중 (kg)</label>
-            <div className={styles.inputWrapper}>
-              <input
-                type='number'
-                value={tempWeight}
-                onChange={(e) => setTempWeight(e.target.value)}
-                placeholder='체중을 입력해주세요. (선택)'
-                min={30}
-                max={300}
-              />
-              <span>kg</span>
-            </div>
-          </div>
-
-          <div className={styles.field}>
             <label>성별</label>
             <div className={styles.genderToggle}>
               <button
                 type='button'
-                className={`${styles.genderBtn} ${tempGender === 'male' ? styles.active : ''}`}
+                className={`${styles.genderBtn} ${styles.male} ${
+                  tempGender === 'male' ? styles.active : ''
+                }`}
                 onClick={() => setTempGender('male')}
               >
                 남성
               </button>
               <button
                 type='button'
-                className={`${styles.genderBtn} ${tempGender === 'female' ? styles.active : ''}`}
+                className={`${styles.genderBtn} ${styles.female} ${
+                  tempGender === 'female' ? styles.active : ''
+                }`}
                 onClick={() => setTempGender('female')}
               >
                 여성
@@ -321,27 +310,36 @@ export default function ProfileEdit({
             </div>
           </div>
 
-          <div className={styles.field}>
-            <label>생년월일</label>
-            <div className={styles.inputWrapper}>
-              <input
-                type='date'
-                value={tempBirthDate}
-                onChange={(e) => setTempBirthDate(e.target.value)}
-                max={new Date().toISOString().split('T')[0]}
-              />
+          <div className={styles.fieldRow}>
+            <div className={styles.field}>
+              <label>체중 (kg)</label>
+              <div className={styles.inputWrapper}>
+                <input
+                  type='number'
+                  value={tempWeight}
+                  onChange={(e) => setTempWeight(e.target.value)}
+                  placeholder='체중 (선택)'
+                  min={30}
+                  max={300}
+                />
+                <span>kg</span>
+              </div>
+            </div>
+
+            <div className={styles.field}>
+              <label>생년월일</label>
+              <div className={styles.inputWrapper}>
+                <input
+                  type='date'
+                  className={styles.dateInput}
+                  value={tempBirthDate}
+                  onChange={(e) => setTempBirthDate(e.target.value)}
+                  max={new Date().toISOString().split('T')[0]}
+                />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-
-      <div className={styles.dangerBtns}>
-        <Button variant='gray' size='sm' onClick={handleReset}>
-          프로필 초기화
-        </Button>
-        <Button variant='red' size='sm' onClick={handleDeleteAccount}>
-          회원 탈퇴
-        </Button>
       </div>
 
       <div className={styles.editBtns}>
@@ -351,6 +349,23 @@ export default function ProfileEdit({
         <Button variant='blue' size='md' onClick={handleConfirmSave}>
           저장
         </Button>
+      </div>
+
+      <div className={styles.dangerZone}>
+        <button
+          type='button'
+          className={styles.dangerLink}
+          onClick={handleReset}
+        >
+          프로필 초기화
+        </button>
+        <button
+          type='button'
+          className={`${styles.dangerLink} ${styles.deleteLink}`}
+          onClick={handleDeleteAccount}
+        >
+          회원 탈퇴
+        </button>
       </div>
     </div>
   );

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -16,6 +16,8 @@ $red-hover: #c82333;
 $blue: #007bff;
 $blue-hover: #0069d9;
 
+$pink: #ec4899;
+
 $liblue: #f0f7ff;
 
 $squat-red: #ef4444;


### PR DESCRIPTION
### 작업 내용
- SCSS 공통 변수에 `$pink` (`#ec4899`) 색상 추가

`ProfileEdit`
- 성별 선택 필드를 체중/생년월일 위쪽으로 이동
- 체중, 생년월일 필드를 한 줄(`fieldRow`)로 배치
- 성별 토글 버튼에 male(blue)/female(pink) 색상 구분 스타일 적용
- 날짜 input 전용 스타일(`dateInput`) 추가
- 프로필 초기화 / 회원 탈퇴 버튼을 하단 버튼(Button 컴포넌트) → 밑줄 텍스트 링크로 변경, 위치를 최하단으로 이동
- 저장/취소 버튼을 위험 액션 영역보다 위쪽으로 재배치

`ProfileCard`
- 프로필 수정 시 `profile` 쿼리뿐 아니라 `users` 쿼리도 함께 invalidate하도록 수정 (목록에 최신 정보 반영 안 되던 문제 해결)
- `ProfileInfo`에 `gender` prop 누락되어 있던 부분 추가 전달
- import 구문 순서 정리 (컴포넌트/훅/유틸 그룹화)
- `profileContainer` border-radius를 `$radius-main` 변수로 교체
- `infoSection` border-radius 값 조정 (24px → 16px)
- `infoContent`에 `overflow-y: auto` 및 스크롤바 숨김 처리 추가 → 편집 폼 등 내용이 길어질 때 카드 영역을 벗어나지 않고 스크롤되도록 개선