### PR TITLE
feat: 프로필 카드 성별 뱃지 표시 기능 추가

### DIFF
--- a/src/components/Profile/components/ProfileInfo/ProfileInfo.module.scss
+++ b/src/components/Profile/components/ProfileInfo/ProfileInfo.module.scss
@@ -53,6 +53,34 @@
         @include font-lg-title;
         font-weight: $font-bold;
         color: $text-dark;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+
+        .genderBadge {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 20px;
+          height: 20px;
+          border-radius: 4px;
+          flex-shrink: 0;
+
+          &.male {
+            background: rgba($blue, 0.12);
+            color: $blue;
+          }
+
+          &.female {
+            background: rgba($pink, 0.12);
+            color: $pink;
+          }
+
+          &.unknown {
+            background: rgba($gray, 0.15);
+            color: $text-muted;
+          }
+        }
       }
     }
   }

--- a/src/components/Profile/components/ProfileInfo/ProfileInfo.tsx
+++ b/src/components/Profile/components/ProfileInfo/ProfileInfo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { Mars, Venus, Minus } from 'lucide-react';
 
 import styles from './ProfileInfo.module.scss';
 
@@ -8,12 +9,38 @@ type ProfileInfoProps = {
   nickname: string;
   avatarUrl: string | null | undefined;
   status: string;
+  gender?: 'male' | 'female' | null;
 };
+
+function GenderBadge({ gender }: { gender?: 'male' | 'female' | null }) {
+  if (gender === 'male') {
+    return (
+      <span className={`${styles.genderBadge} ${styles.male}`}>
+        <Mars size={14} strokeWidth={2.5} />
+      </span>
+    );
+  }
+
+  if (gender === 'female') {
+    return (
+      <span className={`${styles.genderBadge} ${styles.female}`}>
+        <Venus size={14} strokeWidth={2.5} />
+      </span>
+    );
+  }
+
+  return (
+    <span className={`${styles.genderBadge} ${styles.unknown}`}>
+      <Minus size={14} strokeWidth={2.5} />
+    </span>
+  );
+}
 
 export default function ProfileInfo({
   nickname,
   avatarUrl,
   status,
+  gender,
 }: ProfileInfoProps) {
   const hasAvatar = avatarUrl && avatarUrl.trim() !== '';
 
@@ -37,7 +64,10 @@ export default function ProfileInfo({
       <div className={styles.nameWrapper}>
         <div className={styles.textGroup}>
           <span className={styles.subText}>{status}</span>
-          <h2 className={styles.nickname}>{nickname}</h2>
+          <h2 className={styles.nickname}>
+            {nickname}
+            <GenderBadge gender={gender} />
+          </h2>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 작업 내용
- `ProfileInfo` 컴포넌트에 `gender` prop 추가 (`male` / `female` / `null`)
- `lucide-react`의 `Mars`, `Venus`, `Minus` 아이콘을 활용한 `GenderBadge` 도입
- 닉네임 옆에 성별에 따른 뱃지가 노출되도록 UI 변경
- 성별 값에 따라 뱃지 배경색/아이콘 색상 분기 처리
  - 남성: blue 계열
  - 여성: pink 계열
  - 미상(null/undefined): gray 계열
