### PR TITLE
feat: 사용자 프로필에 성별 필드 추가

### DIFF
--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -16,6 +16,7 @@ async function fetchUsers(): Promise<UserSummary[]> {
     avatar_url, 
     status_message,
     is_public,
+    gender,
     records (
       squat, 
       bench_press, 
@@ -62,6 +63,7 @@ async function fetchUsers(): Promise<UserSummary[]> {
       max_total: stats.maxS + stats.maxB + stats.maxD,
       last_activity: stats.lastDate,
       is_public: user.is_public ?? true,
+      gender: user.gender ?? null,
     };
   });
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -9,6 +9,7 @@ export type UserSummary = {
   max_bench: number;
   max_deadlift: number;
   max_total: number;
+  gender: 'male' | 'female' | null;
 };
 
 export type ProfileWithRecords = {
@@ -17,6 +18,7 @@ export type ProfileWithRecords = {
   avatar_url: string | null;
   status_message: string | null;
   is_public: boolean | null;
+  gender: 'male' | 'female' | null;
   records: {
     squat: number | null;
     bench_press: number | null;


### PR DESCRIPTION
### 작업 내용
`user.ts`
  - `UserSummary`, `ProfileWithRecords` 타입에 `gender: 'male' | 'female' | null` 필드 추가
 
`useUsers.ts`
  - `profiles` 쿼리 select 절에 `gender` 컬럼 추가
  - `fetchUsers`에서 반환하는 `UserSummary` 객체에 `gender` 필드 매핑 추가