### PR TITLE
feat: 멤버 목록 카드 성별 뱃지 추가

### DIFF
--- a/src/app/members/components/UserCard/UserCard.module.scss
+++ b/src/app/members/components/UserCard/UserCard.module.scss
@@ -78,6 +78,31 @@
     align-items: center;
     gap: 6px;
 
+    .genderBadge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 18px;
+      height: 18px;
+      border-radius: 4px;
+      flex-shrink: 0;
+
+      &.male {
+        background: rgba($blue, 0.12);
+        color: $blue;
+      }
+
+      &.female {
+        background: rgba($pink, 0.12);
+        color: $pink;
+      }
+
+      &.unknown {
+        background: rgba($gray, 0.15);
+        color: $text-muted;
+      }
+    }
+
     .subscribedBadgeBtn {
       flex-shrink: 0;
       display: inline-flex;

--- a/src/app/members/components/UserCard/UserCard.tsx
+++ b/src/app/members/components/UserCard/UserCard.tsx
@@ -2,23 +2,48 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { UserRoundCheck } from 'lucide-react';
+import { UserRoundCheck, Mars, Venus, Minus } from 'lucide-react';
 
-import styles from './UserCard.module.scss';
+import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
 
-import { UserSummary } from '@/types/user';
+import { useAuth } from '@/hooks/useAuth';
+import { useSubscription } from '@/hooks/useSubscription';
 
 import { formatDate } from '@/utils/dateUtils';
 import { getDisplayDate, getCombinedTotalFromUser } from '@/utils/recordUtils';
 
-import { useAuth } from '@/hooks/useAuth';
-import { useSubscription } from '@/hooks/useSubscription';
-import { ConfirmToast } from '@/components/shared/ConfirmToast/ConfirmToast';
+import { UserSummary } from '@/types/user';
+
+import styles from './UserCard.module.scss';
 
 type UserCardProps = {
   user: UserSummary;
   isSubscribed?: boolean;
 };
+
+function GenderBadge({ gender }: { gender: 'male' | 'female' | null }) {
+  if (gender === 'male') {
+    return (
+      <span className={`${styles.genderBadge} ${styles.male}`}>
+        <Mars size={12} strokeWidth={2.5} />
+      </span>
+    );
+  }
+
+  if (gender === 'female') {
+    return (
+      <span className={`${styles.genderBadge} ${styles.female}`}>
+        <Venus size={12} strokeWidth={2.5} />
+      </span>
+    );
+  }
+
+  return (
+    <span className={`${styles.genderBadge} ${styles.unknown}`}>
+      <Minus size={12} strokeWidth={2.5} />
+    </span>
+  );
+}
 
 export default function UserCard({ user, isSubscribed }: UserCardProps) {
   const isPrivate = user.is_public === false;
@@ -55,7 +80,6 @@ export default function UserCard({ user, isSubscribed }: UserCardProps) {
       <div className={styles.userInfo}>
         <p className={styles.statusMessage}>{user.status_message}</p>
         <h3 className={styles.userName}>
-          {user.nickname}
           {isSubscribed && (
             <button
               type='button'
@@ -66,6 +90,8 @@ export default function UserCard({ user, isSubscribed }: UserCardProps) {
               <UserRoundCheck size={18} className={styles.subscribedBadge} />
             </button>
           )}
+          {user.nickname}
+          <GenderBadge gender={user.gender} />
         </h3>
         <p className={styles.userStats}>
           PR:<span>{getCombinedTotalFromUser(user)}</span>


### PR DESCRIPTION
### 작업 내용
- UserCard 컴포넌트에 성별 표시용 `GenderBadge` 컴포넌트 추가
- 성별 값(male/female/unknown)에 따라 Mars/Venus/Minus 아이콘 및 색상(blue/pink/gray)으로 구분 표시
- 닉네임 옆에 성별 뱃지 렌더링되도록 배치
- 팔로우 취소 버튼 위치를 닉네임 앞쪽으로 이동
- import 순서 정리