### PR TITLE
feat: 멤버 목록 페이지 성별 그룹핑 및 그룹별 페이지네이션 적용

### DIFF
--- a/src/app/members/Members.module.scss
+++ b/src/app/members/Members.module.scss
@@ -10,17 +10,6 @@
     color: $text-dark;
     text-align: center;
   }
-
-  .userGrid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1rem;
-    margin: 20px;
-
-    @media (min-width: 768px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
 }
 
 .filterTabs {
@@ -30,5 +19,37 @@
 
   button {
     color: $text-muted;
+  }
+}
+
+.genderSections {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.genderSection {
+  .genderSectionTitle {
+    @include font-lg-title;
+    color: $text-dark;
+    margin: 0 20px 12px;
+
+    span {
+      @include font-sm;
+      color: $text-muted;
+      font-weight: 400;
+      margin-left: 4px;
+    }
+  }
+}
+
+.userRow {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin: 0 20px 12px;
+
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -2,23 +2,39 @@
 
 import { useEffect, useMemo, useState } from 'react';
 
-import styles from './Members.module.scss';
+import Button from '@/components/shared/Button/Button';
+import Empty from '@/components/shared/Empty/Empty';
+import Loading from '@/components/shared/Loading/Loading';
+import NavBar from '@/components/shared/NavBar/NavBar';
+import Pagination from '@/components/shared/Pagination/Pagination';
+
+import { useAuth } from '@/hooks/useAuth';
+import { useMySubscribers } from '@/hooks/useMySubscribers';
+import { useMySubscriptions } from '@/hooks/useMySubscriptions';
+import { useUsers } from '@/hooks/useUsers';
+
+import { UserSummary } from '@/types/user';
 
 import UserCard from './components/UserCard/UserCard';
 
-import Pagination from '@/components/shared/Pagination/Pagination';
-import Loading from '@/components/shared/Loading/Loading';
-import NavBar from '@/components/shared/NavBar/NavBar';
-import Button from '@/components/shared/Button/Button';
+import styles from './Members.module.scss';
 
-import { useUsers } from '@/hooks/useUsers';
-import { useAuth } from '@/hooks/useAuth';
-import { useMySubscriptions } from '@/hooks/useMySubscriptions';
-import { useMySubscribers } from '@/hooks/useMySubscribers';
-
-const PAGE_SIZE = 8;
+const GENDER_GROUP_PAGE_SIZE = 4;
 
 type FilterType = 'all' | 'subscribed' | 'subscribers';
+type GenderGroupKey = 'male' | 'female' | 'unknown';
+
+const GENDER_GROUPS: { key: GenderGroupKey; label: string }[] = [
+  { key: 'male', label: '남성' },
+  { key: 'female', label: '여성' },
+  { key: 'unknown', label: '미설정' },
+];
+
+function getGenderGroup(user: UserSummary): GenderGroupKey {
+  if (user.gender === 'male') return 'male';
+  if (user.gender === 'female') return 'female';
+  return 'unknown';
+}
 
 export default function MembersPage() {
   const { user } = useAuth();
@@ -29,8 +45,14 @@ export default function MembersPage() {
     user?.id,
   );
 
-  const [currentPage, setCurrentPage] = useState<number>(1);
   const [filter, setFilter] = useState<FilterType>('all');
+
+  // 그룹별 독립 페이지 상태
+  const [groupPages, setGroupPages] = useState<Record<GenderGroupKey, number>>({
+    male: 1,
+    female: 1,
+    unknown: 1,
+  });
 
   // 로그아웃 시 필터 초기화
   useEffect(() => {
@@ -63,16 +85,27 @@ export default function MembersPage() {
     return sortedUsers;
   }, [sortedUsers, filter, subscribedIds, subscriberIds]);
 
-  const paginatedUsers = useMemo(() => {
-    return filteredUsers.slice(
-      (currentPage - 1) * PAGE_SIZE,
-      currentPage * PAGE_SIZE,
-    );
-  }, [filteredUsers, currentPage]);
+  // 성별 분류
+  const groupedUsers = useMemo(() => {
+    const groups: Record<GenderGroupKey, UserSummary[]> = {
+      male: [],
+      female: [],
+      unknown: [],
+    };
+    filteredUsers.forEach((u) => {
+      groups[getGenderGroup(u)].push(u);
+    });
+    return groups;
+  }, [filteredUsers]);
 
+  // 필터 변경 시 그룹 페이지 초기화
   const handleFilterChange = (next: FilterType) => {
     setFilter(next);
-    setCurrentPage(1);
+    setGroupPages({ male: 1, female: 1, unknown: 1 });
+  };
+
+  const handleGroupPageChange = (key: GenderGroupKey, page: number) => {
+    setGroupPages((prev) => ({ ...prev, [key]: page }));
   };
 
   if (loading || subsLoading || subscribersLoading)
@@ -113,22 +146,49 @@ export default function MembersPage() {
         </div>
       )}
 
-      <div className={styles.userGrid}>
-        {paginatedUsers.map((u) => (
-          <UserCard
-            key={u.id}
-            user={u}
-            isSubscribed={subscribedIds.has(u.id)}
-          />
-        ))}
-      </div>
+      {filteredUsers.length === 0 ? (
+        <Empty message='표시할 멤버가 없어요.' />
+      ) : (
+        <div className={styles.genderSections}>
+          {GENDER_GROUPS.map(({ key, label }) => {
+            const groupList = groupedUsers[key];
+            if (groupList.length === 0) return null;
 
-      <Pagination
-        totalCount={filteredUsers.length}
-        pageSize={PAGE_SIZE}
-        currentPage={currentPage}
-        onPageChange={setCurrentPage}
-      />
+            const currentPage = groupPages[key];
+            const paginated = groupList.slice(
+              (currentPage - 1) * GENDER_GROUP_PAGE_SIZE,
+              currentPage * GENDER_GROUP_PAGE_SIZE,
+            );
+
+            return (
+              <section key={key} className={styles.genderSection}>
+                <h2 className={styles.genderSectionTitle}>
+                  {label} <span>{groupList.length}</span>
+                </h2>
+
+                <div className={styles.userRow}>
+                  {paginated.map((u) => (
+                    <UserCard
+                      key={u.id}
+                      user={u}
+                      isSubscribed={subscribedIds.has(u.id)}
+                    />
+                  ))}
+                </div>
+
+                {groupList.length > GENDER_GROUP_PAGE_SIZE && (
+                  <Pagination
+                    totalCount={groupList.length}
+                    pageSize={GENDER_GROUP_PAGE_SIZE}
+                    currentPage={currentPage}
+                    onPageChange={(page) => handleGroupPageChange(key, page)}
+                  />
+                )}
+              </section>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### 작업 내용
- 전체 필터링된 사용자 목록을 8개 단위로 페이지네이션하던 단일 그리드 방식 제거
- 남성/여성/미설정 성별 그룹으로 분류하여 각 그룹마다 독립적인 페이지네이션(4개 단위) 적용
- 필터(전체/팔로워/팔로잉) 변경 시 모든 그룹의 페이지를 1로 초기화
- 표시할 멤버가 없을 때 `Empty` 컴포넌트로 안내 메시지 노출
- 단일 그리드(`userGrid`) 스타일 제거, 그룹 섹션(`genderSections`), 그룹 타이틀(`genderSectionTitle`), 그룹별 카드 그리드(`userRow`) 스타일 추가
