### PR TITLE
feat: 대시보드 모바일 화면에서 기록/프로필 탭 전환 UI 추가

### DIFF
--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -19,6 +19,43 @@
   }
 }
 
+.mobileSwitcher {
+  display: none;
+}
+
+.mobilePanel {
+  display: flex;
+  min-width: 0;
+
+  & > * {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+@media (max-width: 1299px) {
+  .mobileSwitcher {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    width: 100%;
+
+    button {
+      @include font-body;
+      width: 100%;
+      gap: 6px;
+    }
+  }
+
+  .mobilePanel {
+    display: none;
+  }
+
+  .activeMobilePanel {
+    display: flex;
+  }
+}
+
 .guestGrid {
   display: flex;
   flex-direction: column;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+import { useState } from 'react';
+import { ClipboardList, UserRound } from 'lucide-react';
+
 import Empty from '@/components/shared/Empty/Empty';
 import NavBar from '@/components/shared/NavBar/NavBar';
+import Button from '@/components/shared/Button/Button';
 
 import RecordForm from '@/components/RecordForm/RecordForm';
 import RecordList from '@/components/RecordList/RecordList';
@@ -12,8 +16,12 @@ import { useAuth } from '@/hooks/useAuth';
 
 import styles from './page.module.scss';
 
+type MobilePanel = 'record' | 'profile';
+
 export default function Home() {
   const { user, loading } = useAuth();
+  const [activeMobilePanel, setActiveMobilePanel] =
+    useState<MobilePanel>('record');
 
   if (loading) return null;
 
@@ -23,8 +31,50 @@ export default function Home() {
 
       {user ? (
         <div className={styles.dashboardGrid}>
-          <RecordForm />
-          <ProfileCard />
+          <div
+            className={styles.mobileSwitcher}
+            role='tablist'
+            aria-label='모바일 대시보드 전환'
+          >
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              active={activeMobilePanel === 'record'}
+              onClick={() => setActiveMobilePanel('record')}
+              role='tab'
+              aria-selected={activeMobilePanel === 'record'}
+            >
+              <ClipboardList size={16} />
+              기록
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              active={activeMobilePanel === 'profile'}
+              onClick={() => setActiveMobilePanel('profile')}
+              role='tab'
+              aria-selected={activeMobilePanel === 'profile'}
+            >
+              <UserRound size={16} />
+              프로필
+            </Button>
+          </div>
+          <div
+            className={`${styles.mobilePanel} ${
+              activeMobilePanel === 'record' ? styles.activeMobilePanel : ''
+            }`}
+          >
+            <RecordForm />
+          </div>
+          <div
+            className={`${styles.mobilePanel} ${
+              activeMobilePanel === 'profile' ? styles.activeMobilePanel : ''
+            }`}
+          >
+            <ProfileCard />
+          </div>
           <Charts />
           <RecordList />
         </div>


### PR DESCRIPTION
### 작업 내용
- `activeMobilePanel` 상태를 추가하여 현재 활성화된 패널(record/profile) 관리
- 모바일 전용 탭 스위처(`mobileSwitcher`) UI 추가
- 각 탭 버튼에 `role='tab'`, `aria-selected` 속성을 적용하여 접근성 개선
- `mobilePanel` / `activeMobilePanel` 클래스로 선택된 패널만 노출되도록 스타일 처리
- 미디어쿼리(`max-width: 1299px`) 기준으로 데스크톱/모바일 레이아웃 분기