### PR TITLE
feat: 맨 위로 가기 버튼 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,15 +2,16 @@ import { Toaster } from 'sonner';
 
 import AuthForm from '@/components/AuthForm/AuthForm';
 import InstallBanner from '@/components/InstallBanner/InstallBanner';
+import ScrollToTopButton from '@/components/shared/ScrollToTopButton/ScrollToTopButton';
 
 import QueryProvider from '@/providers/QueryProvider';
 
 import '@/styles/globals.scss';
 import { Font } from '@/styles/fonts';
 
-import styles from './layout.module.scss';
-
 export { metadata, viewport } from './metadata';
+
+import styles from './layout.module.scss';
 
 export default function RootLayout({
   children,
@@ -27,6 +28,7 @@ export default function RootLayout({
               <AuthForm />
               {children}
             </main>
+            <ScrollToTopButton />
           </div>
         </QueryProvider>
         <Toaster

--- a/src/components/shared/ScrollToTopButton/ScrollToTopButton.module.scss
+++ b/src/components/shared/ScrollToTopButton/ScrollToTopButton.module.scss
@@ -1,0 +1,43 @@
+@use '../../../styles' as *;
+
+.scrollToTopButton {
+  position: fixed;
+  left: 50%;
+  bottom: calc(24px + env(safe-area-inset-bottom));
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border: 1px solid $border-soft;
+  border-radius: 50%;
+  background: $white;
+  color: $text-dark;
+  box-shadow: $shadow-lg;
+  cursor: pointer;
+  transition:
+    opacity 0.25s ease,
+    transform 0.25s ease,
+    visibility 0.25s ease;
+
+  opacity: 0;
+  transform: translateX(-50%) translateY(16px);
+  visibility: hidden;
+  pointer-events: none;
+
+  &[data-visible='true'] {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  &:hover {
+    transform: translateX(-50%) translateY(-2px);
+  }
+
+  &[data-visible='true']:active {
+    transform: translateX(-50%) translateY(0);
+  }
+}

--- a/src/components/shared/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/src/components/shared/ScrollToTopButton/ScrollToTopButton.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ArrowUp, ArrowUpToLine, ChevronUp } from 'lucide-react';
+
+import styles from './ScrollToTopButton.module.scss';
+
+const SHOW_SCROLL_Y = 300;
+const SCROLL_DELTA_THRESHOLD = 10;
+
+export default function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+  const lastScrollY = useRef(0);
+  const ticking = useRef(false);
+
+  useEffect(() => {
+    lastScrollY.current = window.scrollY;
+
+    const updateVisibility = () => {
+      const currentY = window.scrollY;
+      const delta = currentY - lastScrollY.current;
+
+      if (currentY <= SHOW_SCROLL_Y) {
+        setIsVisible(false);
+      } else if (delta > SCROLL_DELTA_THRESHOLD) {
+        setIsVisible(false);
+        lastScrollY.current = currentY;
+      } else if (delta < -SCROLL_DELTA_THRESHOLD) {
+        setIsVisible(true);
+        lastScrollY.current = currentY;
+      }
+
+      ticking.current = false;
+    };
+
+    const handleScroll = () => {
+      if (!ticking.current) {
+        window.requestAnimationFrame(updateVisibility);
+        ticking.current = true;
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <button
+      type='button'
+      className={styles.scrollToTopButton}
+      data-visible={isVisible}
+      onClick={scrollToTop}
+      aria-label='맨 위로 가기'
+      aria-hidden={!isVisible}
+      tabIndex={isVisible ? 0 : -1}
+    >
+      <ChevronUp size={22} aria-hidden='true' />
+    </button>
+  );
+}


### PR DESCRIPTION
## 작업 내용
- `ScrollToTopButton.tsx`
  - 스크롤 위치(`SHOW_SCROLL_Y`)에 따라 버튼 노출 여부 제어
  - 아래로 스크롤 시 버튼 숨김, 위로 스크롤 시 버튼 노출 (스크롤 델타 기반)
  - `requestAnimationFrame`을 이용한 스크롤 이벤트 쓰로틀링 처리
  - 클릭 시 `scrollTo({ behavior: 'smooth' })`로 부드럽게 최상단 이동

- `ScrollToTopButton.module.scss`
  - 화면 하단 중앙 고정 위치, 원형 버튼 UI
  - `data-visible` 속성 기반 노출/숨김 트랜지션 적용
  - hover/active 인터랙션 스타일 추가
  - `env(safe-area-inset-bottom)` 적용으로 노치 기기 대응

- `RootLayout`에 컴포넌트 적용
  - `main` 영역과 형제 요소로 배치하여 전역에서 노출되도록 구성
