### PR TITLE
fix: 데이터 부재 탭에서 auto 높이 정상 반영되지 않던 문제 수정

### DIFF
--- a/src/components/Charts/Charts.module.scss
+++ b/src/components/Charts/Charts.module.scss
@@ -11,6 +11,10 @@ $chart-height-mobile: 650px;
   @media (max-width: 768px) {
     height: $chart-height-mobile;
   }
+
+  &.auto {
+    height: auto;
+  }
 }
 
 .chartPane {
@@ -20,6 +24,8 @@ $chart-height-mobile: 650px;
   transition: opacity 0.15s ease;
 
   &.auto {
+    position: relative;
+    inset: auto;
     height: auto;
   }
 }
@@ -28,14 +34,12 @@ $chart-height-mobile: 650px;
   visibility: visible;
   opacity: 1;
   pointer-events: auto;
-  z-index: 1;
 }
 
 .inactive {
   visibility: hidden;
   opacity: 0;
   pointer-events: none;
-  z-index: 0;
 }
 
 .tabGroup {

--- a/src/components/Charts/Charts.tsx
+++ b/src/components/Charts/Charts.tsx
@@ -44,6 +44,8 @@ export default function Charts({ userId }: ChartsProps) {
     );
   };
 
+  const shouldUseAutoHeight = !hasData[activeView];
+
   const tabButtons = (
     <div className={styles.tabGroup}>
       {TABS.map((tab) => (
@@ -60,12 +62,16 @@ export default function Charts({ userId }: ChartsProps) {
   );
 
   return (
-    <div className={styles.chartsWrapper}>
+    <div
+      className={`${styles.chartsWrapper} ${
+        shouldUseAutoHeight ? styles.auto : ''
+      }`}
+    >
       {mountedViews.record && (
         <div
           className={`${styles.chartPane} ${
             activeView === 'record' ? styles.active : styles.inactive
-          } ${!hasData.record ? styles.auto : ''}`}
+          } ${activeView === 'record' && !hasData.record ? styles.auto : ''}`}
         >
           <RecordChart
             userId={userId}
@@ -79,7 +85,9 @@ export default function Charts({ userId }: ChartsProps) {
         <div
           className={`${styles.chartPane} ${
             activeView === 'strength' ? styles.active : styles.inactive
-          } ${!hasData.strength ? styles.auto : ''}`}
+          } ${
+            activeView === 'strength' && !hasData.strength ? styles.auto : ''
+          }`}
         >
           <StrengthChart
             userId={userId}
@@ -93,7 +101,11 @@ export default function Charts({ userId }: ChartsProps) {
         <div
           className={`${styles.chartPane} ${
             activeView === 'bodyweight' ? styles.active : styles.inactive
-          } ${!hasData.bodyweight ? styles.auto : ''}`}
+          } ${
+            activeView === 'bodyweight' && !hasData.bodyweight
+              ? styles.auto
+              : ''
+          }`}
         >
           <BodyweightChart
             userId={userId}


### PR DESCRIPTION
### 작업 내용
`Charts.tsx`
- `auto` 클래스 적용 조건에 `activeView === key` 체크를 추가하여 비활성 탭의 `hasData` 상태가 다른 탭의 스타일에 영향을 주지 않도록 수정
- `chartsWrapper`에도 `shouldUseAutoHeight` 값을 기반으로 `auto` 클래스를 추가해 활성 탭 기준으로 wrapper 레벨 높이도 함께 축소되도록 개선

`Charts.module.scss`
- `chartPane.auto`에 `position: relative; inset: auto;` 추가
  - 기존 `position: absolute; inset: 0;` 상태에서 `height: auto`만 적용해 실질적으로 부모 높이를 그대로 상속받아 auto 효과가 없었음
  - `position`을 해제해 문서 흐름을 따르게 함으로써 콘텐츠 높이만큼 실제로 줄어들도록 수정
- `chartsWrapper.auto` 클래스 추가로 wrapper도 동일하게 auto 높이 적용
- `active`/`inactive`의 `z-index` 제거 (absolute 구조 변경에 따라 불필요)