### PR TITLE
fix: 프로필 편집 성별/생년월일 필드 중복 렌더링 제거

### DIFF
--- a/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
+++ b/src/components/Profile/components/ProfileEdit/ProfileEdit.tsx
@@ -339,38 +339,6 @@ export default function ProfileEdit({
               </div>
             </div>
           </div>
-
-          <div className={styles.field}>
-            <label>성별</label>
-            <div className={styles.genderToggle}>
-              <button
-                type='button'
-                className={`${styles.genderBtn} ${tempGender === 'male' ? styles.active : ''}`}
-                onClick={() => setTempGender('male')}
-              >
-                남성
-              </button>
-              <button
-                type='button'
-                className={`${styles.genderBtn} ${tempGender === 'female' ? styles.active : ''}`}
-                onClick={() => setTempGender('female')}
-              >
-                여성
-              </button>
-            </div>
-          </div>
-
-          <div className={styles.field}>
-            <label>생년월일</label>
-            <div className={styles.inputWrapper}>
-              <input
-                type='date'
-                value={tempBirthDate}
-                onChange={(e) => setTempBirthDate(e.target.value)}
-                max={new Date().toISOString().split('T')[0]}
-              />
-            </div>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
### 작업 내용
- 중복 렌더링되던 두 번째 `성별` 필드(`genderToggle`) 삭제
- 중복 렌더링되던 두 번째 `생년월일` 필드(`inputWrapper`) 삭제